### PR TITLE
Update ios installation step

### DIFF
--- a/docs/ios-installation.md
+++ b/docs/ios-installation.md
@@ -11,7 +11,7 @@ react-native link react-native-callkeep
 Include in a Podfile in your react-native `ios` directory:
 
 ```
-pod 'react-native-callkeep', :path => '../node_modules/react-native-callkeep'
+pod 'RNCallKeep', :path => '../node_modules/react-native-callkeep'
 ```
 
 Then:


### PR DESCRIPTION
The file link inside the Podfile was giving this error 
[!] No podspec found for `react-native-callkeep` in `../node_modules/react-native-callkeep` 
since the related name in the podspec file is `RNCallKeep` and not `react-native-callkeep`