### PR TITLE
Fix #54 and ReportUpdatedCall API

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,12 +90,12 @@ class RNCallKeep {
   };
 
   checkIfBusy = () =>
-    Platform.OS === 'ios'
+    isIOS
       ? RNCallKeepModule.checkIfBusy()
       : Promise.reject('RNCallKeep.checkIfBusy was called from unsupported OS');
 
   checkSpeaker = () =>
-    Platform.OS === 'ios'
+    isIOS
       ? RNCallKeepModule.checkSpeaker()
       : Promise.reject('RNCallKeep.checkSpeaker was called from unsupported OS');
 
@@ -116,9 +116,9 @@ class RNCallKeep {
     RNCallKeepModule.setCurrentCallActive();
   };
 
-  reportUpdatedCall(uuid, localizedCallerName?: String) {
-    return Platform.OS === 'ios'
-      ? _RNCallKit.reportUpdatedCall(uuid, localizedCallerName)
+  reportUpdatedCall(uuid, localizedCallerName) {
+    return isIOS
+      ? RNCallKeepModule.reportUpdatedCall(uuid, localizedCallerName)
       : Promise.reject('RNCallKeep.reportUpdatedCall was called from unsupported OS');
   }
 

--- a/index.js
+++ b/index.js
@@ -116,6 +116,12 @@ class RNCallKeep {
     RNCallKeepModule.setCurrentCallActive();
   };
 
+  reportUpdatedCall(uuid, localizedCallerName?: String) {
+    return Platform.OS === 'ios'
+      ? _RNCallKit.reportUpdatedCall(uuid, localizedCallerName)
+      : Promise.reject('RNCallKeep.reportUpdatedCall was called from unsupported OS');
+  }
+
   _setupIOS = async (options) => new Promise((resolve, reject) => {
     if (!options.appName) {
       reject('RNCallKeep.setup: option "appName" is required');

--- a/index.js
+++ b/index.js
@@ -116,11 +116,10 @@ class RNCallKeep {
     RNCallKeepModule.setCurrentCallActive();
   };
 
-  reportUpdatedCall(uuid, localizedCallerName) {
-    return isIOS
+  reportUpdatedCall = (uuid, localizedCallerName) =>
+    isIOS
       ? RNCallKeepModule.reportUpdatedCall(uuid, localizedCallerName)
       : Promise.reject('RNCallKeep.reportUpdatedCall was called from unsupported OS');
-  }
 
   _setupIOS = async (options) => new Promise((resolve, reject) => {
     if (!options.appName) {

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -132,7 +132,7 @@ RCT_EXPORT_METHOD(displayIncomingCall:(NSString *)uuidString
     callUpdate.supportsHolding = YES;
     callUpdate.supportsGrouping = YES;
     callUpdate.supportsUngrouping = YES;
-    callUpdate.hasVideo = NO;
+    callUpdate.hasVideo = hasVideo;
     callUpdate.localizedCallerName = localizedCallerName;
 
     [self.callKeepProvider reportNewIncomingCallWithUUID:uuid update:callUpdate completion:^(NSError * _Nullable error) {

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -444,7 +444,7 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
     callUpdate.localizedCallerName = contactIdentifier;
 
-    [self.callKitProvider reportCallWithUUID:uuid updated:callUpdate];
+    [self.callKeepProvider reportCallWithUUID:uuid updated:callUpdate];
 }
 
 // Answering incoming call

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -247,11 +247,12 @@ RCT_EXPORT_METHOD(setMutedCall:(NSString *)uuidString muted:(BOOL)muted)
                 CXStartCallAction *startCallAction = [transaction.actions firstObject];
                 CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
                 callUpdate.remoteHandle = startCallAction.handle;
+                callUpdate.hasVideo = startCallAction.video;
+                callUpdate.localizedCallerName = startCallAction.contactIdentifier;
                 callUpdate.supportsDTMF = YES;
                 callUpdate.supportsHolding = YES;
                 callUpdate.supportsGrouping = YES;
                 callUpdate.supportsUngrouping = YES;
-                callUpdate.hasVideo = NO;
                 [self.callKeepProvider reportCallWithUUID:startCallAction.callUUID updated:callUpdate];
             }
         }
@@ -431,6 +432,19 @@ continueUserActivity:(NSUserActivity *)userActivity
     [self.callKeepProvider reportOutgoingCallWithUUID:action.callUUID startedConnectingAtDate:[NSDate date]];
     [self configureAudioSession];
     [action fulfill];
+}
+
+// Update call contact info
+RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NSString *)contactIdentifier)
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKeep][reportUpdatedCall] contactIdentifier = %i", contactIdentifier);
+#endif
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+    CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
+    callUpdate.localizedCallerName = contactIdentifier;
+
+    [self.callKitProvider reportCallWithUUID:uuid updated:callUpdate];
 }
 
 // Answering incoming call


### PR DESCRIPTION
- Adds the ability to change the update call's localizedCallerName. This is useful for updating call info when you have a group call session and new participants join

- Fixes bug where startCallAction would not properly report the localizedCallerName passed with the transaction action in the system dialer history
- Fix bug where `displayIncomingCall` would not correctly reflect when the call is a video call in the system dialier history and on call ux (https://github.com/react-native-webrtc/react-native-callkeep/issues/54)