### PR TITLE
enable an event into rtcaudio session

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -573,6 +573,13 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][CXProviderDelegate][provider:didActivateAudioSession]");
 #endif
+    NSDictionary *userInfo
+        = @{
+            AVAudioSessionInterruptionTypeKey: [NSNumber numberWithInt:AVAudioSessionInterruptionTypeEnded],
+            AVAudioSessionInterruptionOptionKey: [NSNumber numberWithInt:AVAudioSessionInterruptionOptionShouldResume]
+            };
+    [[NSNotificationCenter defaultCenter] postNotificationName:AVAudioSessionInterruptionNotification object:nil userInfo:userInfo];
+
     [self configureAudioSession];
     [self sendEventWithName:RNCallKeepDidActivateAudioSession body:nil];
 }


### PR DESCRIPTION
this enables M75 of ios WebRTC SDK to start/stop audio session

In callkit  the audio session gets deactivated and we need a way of restarting it. This, in addition to a field trial in M75 allows that to happen. If you don't have M75 the event does no harm

thanks to @saghul for helping figure this one out