### PR TITLE
Introduce hasOutgoingCall for Android background mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,20 @@ _This feature is available only on Android._
 await RNCallKeep.hasPhoneAccount();
 ```
 
+### hasOutgoingCall (async)
+
+_This feature is available only on Android, useful when waking up the application for an outgoing call._
+
+When waking up the Android application in background mode (eg: when the application is killed and the user make a call from the native Phone application).
+The user can hang up the call before your application has been started in background mode, and you can lost the `RNCallKeepPerformEndCallAction` event.
+
+To be sure that the outgoing call is still here, you can call `hasOutgoingCall` when you app waken up.
+
+
+```js
+const hasOutgoingCall = await RNCallKeep.hasOutgoingCall();
+```
+
 ### hasDefaultPhoneAccount
 
 Checks if the user has set a default [phone account](https://developer.android.com/reference/android/telecom/PhoneAccount).

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -341,6 +341,11 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void hasOutgoingCall(Promise promise) {
+        promise.resolve(VoiceConnectionService.hasOutgoingCall);
+    }
+
+    @ReactMethod
     public void hasPermissions(Promise promise) {
         promise.resolve(this.hasPermissions());
     }

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -73,6 +73,7 @@ public class VoiceConnectionService extends ConnectionService {
     private static Boolean isAvailable = false;
     private static String TAG = "RNCK:VoiceConnectionService";
     public static Map<String, VoiceConnection> currentConnections = new HashMap<>();
+    public static Boolean hasOutgoingCall = false;
 
     public static Connection getConnection(String connectionId) {
         if (currentConnections.containsKey(connectionId)) {
@@ -93,6 +94,8 @@ public class VoiceConnectionService extends ConnectionService {
 
     public static void deinitConnection(String connectionId) {
         Log.d(TAG, "deinitConnection:" + connectionId);
+        VoiceConnectionService.hasOutgoingCall = false;
+
         if (currentConnections.containsKey(connectionId)) {
             currentConnections.remove(connectionId);
         }
@@ -112,6 +115,8 @@ public class VoiceConnectionService extends ConnectionService {
 
     @Override
     public Connection onCreateOutgoingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
+        VoiceConnectionService.hasOutgoingCall = true;
+
         Bundle extras = request.getExtras();
         Connection outgoingCallConnection = null;
         String number = request.getAddress().getSchemeSpecificPart();

--- a/index.js
+++ b/index.js
@@ -112,13 +112,16 @@ class RNCallKeep {
   hasPhoneAccount = async () =>
     isIOS ? true : await RNCallKeepModule.hasPhoneAccount();
 
+  hasOutgoingCall = async () =>
+    isIOS ? null : await RNCallKeepModule.hasOutgoingCall();
+
   setMutedCall = (uuid, shouldMute) => {
     RNCallKeepModule.setMutedCall(uuid, shouldMute);
   };
 
   sendDTMF = (uuid, key) => {
     RNCallKeepModule.sendDTMF(uuid, key);
-  }
+  };
 
   checkIfBusy = () =>
     isIOS


### PR DESCRIPTION
On Android, when the application is killed and user make a call via the Phone app, the application may take 5/10s to be started in background mode.
During this time, if the user hangup the call, we'll miss the `RNCallKeepPerformEndCallAction` event (because the application is not yet started).

To avoid this issue, I've introduced the `hasOutgoingCall()` method to be sure that the call is still alive.