### PR TITLE
Fix outgoing native calls on iOS when app is killed

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -15,8 +15,14 @@ const RNCallKeepDidPerformDTMFAction = 'RNCallKeepDidPerformDTMFAction';
 const RNCallKeepProviderReset = 'RNCallKeepProviderReset';
 const isIOS = Platform.OS === 'ios';
 
-const didReceiveStartCallAction = handler => 
+const didReceiveStartCallAction = handler => {
   eventEmitter.addListener(RNCallKeepDidReceiveStartCallAction, (data) => handler(data));
+
+  if (isIOS) {
+    // Tell CallKeep that we are ready to receive `RNCallKeepDidReceiveStartCallAction` event and prevent delay
+    RNCallKeepModule._startCallActionEventListenerAdded();
+  }
+};
 
 const answerCall = handler =>
   eventEmitter.addListener(RNCallKeepPerformAnswerCallAction, (data) => handler(data));


### PR DESCRIPTION
On iOS when waking up the app with a native outgoing call, we have sometimes an error :
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Error when sending event: RNCallKeepDidReceiveStartCallAction with body: {
    handle = "\U202d802-6\U202c";
    video = 0;
}. Bridge is not set. This is probably because you've explicitly synthesized the bridge in RNCallKeep, even though it's inherited from RCTEventEmitter.'
*** First throw call stack:
(0x19366127c 0x19283b9f8 0x19357a988 0x19408aee8 0x10046c170 0x100747014 0x1930a17d4 0x193046018 0x193055fa4 0x19304eee8 0x1935f2c1c 0x1935edb54 0x1935ed0b0 0x1957ed79c 0x1bfe1c978 0x1002dbe8c 0x1930b28e0)
```

This is due to the observer that doesn't share the same instance of CallKeep. I've fixed that [with a Singleton](https://github.com/facebook/react-native/issues/15421#issuecomment-335346159).

Another issue we have is this error :
```
Sending `RNCallKeepHandleStartCallNotification` with no listeners registered.
```

This is due to the app that didn't bind the event before it is sent. Event when we bind this event directly at the top of `index.ios.js`.

I've increased the workaround delay. I don't have any other idea to fix that...