### PR TITLE
Minor updates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+# Bug report
+
+- [ ] I've checked the [example](https://github.com/react-native-webrtc/react-native-callkeep/tree/master/example) to reproduce the issue.
+
+- Reproduced on:
+ - [ ] Android
+ - [ ] iOS
+
+## Description
+
+
+## Steps to Reproduce
+
+
+## Versions
+    - Callkeep:
+    - React Native:
+    - iOS:
+    - Android:
+    - Phone model: 
+
+
+## Logs
+
+```
+Paste here
+```

--- a/README.md
+++ b/README.md
@@ -187,15 +187,14 @@ Sets the Android caller name and number
 Use this to update the Android display after an outgoing call has started
 
 ```js
-RNCallKeep.updateDisplay(uuid, localizedCallerName, handle)
+RNCallKeep.updateDisplay(uuid, displayName, handle)
 ```
 - `uuid`: string
   - The `uuid` used for `startCall` or `displayIncomingCall`
+- `displayName`: string (optional)
+  - Name of the caller to be displayed on the native UI
 - `handle`: string
   - Phone number of the caller
-- `localizedCallerName`: string (optional)
-  - Name of the caller to be displayed on the native UI
-
 
 ### endCall
 

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -91,7 +91,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     private static final String[] permissions = { Manifest.permission.READ_PHONE_STATE,
             Manifest.permission.CALL_PHONE, Manifest.permission.RECORD_AUDIO };
 
-    private static final String TAG = "RNCallKeepModule";
+    private static final String TAG = "RNCK:RNCallKeepModule";
     private static TelecomManager telecomManager;
     private static TelephonyManager telephonyManager;
     private static Promise hasPhoneAccountPromise;

--- a/example/App.js
+++ b/example/App.js
@@ -54,6 +54,8 @@ const format = uuid => uuid.split('-')[0];
 
 const getRandomNumber = () => String(Math.floor(Math.random() * 100000));
 
+const isIOS = Platform.OS === 'ios';
+
 export default function App() {
   const [logText, setLog] = useState('');
   const [heldCalls, setHeldCalls] = useState({}); // callKeep uuid: held
@@ -182,6 +184,18 @@ export default function App() {
     setCallMuted(callUUID, muted);
   };
 
+  const updateDisplay = (callUUID) => {
+    const number = calls[callUUID];
+    // Workaround because Android doesn't display well displayName, se we have to switch ...
+    if (isIOS) {
+      RNCallKeep.updateDisplay(callUUID, 'New Name', number);
+    } else {
+      RNCallKeep.updateDisplay(callUUID, number, 'New Name');
+    }
+
+    log(`[updateDisplay: ${number}] ${format(callUUID)}`);
+  };
+
   useEffect(() => {
     RNCallKeep.addEventListener('answerCall', answerCall);
     RNCallKeep.addEventListener('didPerformDTMFAction', didPerformDTMFAction);
@@ -200,7 +214,7 @@ export default function App() {
     }
   }, []);
 
-  if (Platform.OS === 'ios' && DeviceInfo.isEmulator()) {
+  if (isIOS && DeviceInfo.isEmulator()) {
     return <Text style={styles.container}>CallKeep doesn't work on iOS emulator</Text>;
   }
 
@@ -222,6 +236,14 @@ export default function App() {
             hitSlop={hitSlop}
           >
             <Text>{heldCalls[callUUID] ? 'Unhold' : 'Hold'} {calls[callUUID]}</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            onPress={() => updateDisplay(callUUID)}
+            style={styles.button}
+            hitSlop={hitSlop}
+          >
+            <Text>Update display</Text>
           </TouchableOpacity>
 
           <TouchableOpacity

--- a/example/ios/CallKeepDemo.xcodeproj/xcshareddata/xcschemes/CallKeepDemo.xcscheme
+++ b/example/ios/CallKeepDemo.xcodeproj/xcshareddata/xcschemes/CallKeepDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^16.8.6",
     "react-native": "0.59.8",
     "react-native-background-timer": "^2.1.1",
-    "react-native-callkeep": "https://github.com/react-native-webrtc/react-native-callkeep",
+    "react-native-callkeep": "https://github.com/react-native-webrtc/react-native-callkeep#fix_outgoing_call_ios",
     "react-native-device-info": "^2.3.2",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-reanimated": "~1.1.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4132,9 +4132,9 @@ react-native-branch@~3.0.1:
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-3.0.1.tgz#5b07b61cbd290168cd3c3662e017ebe0f356d2ca"
   integrity sha512-vbcYxPZlpF5f39GAEUF8kuGQqCNeD3E6zEdvtOq8oCGZunHXlWlKgAS6dgBKCvsHvXgHuMtpvs39VgOp8DaKig==
 
-"react-native-callkeep@https://github.com/react-native-webrtc/react-native-callkeep":
-  version "3.0.0"
-  resolved "https://github.com/react-native-webrtc/react-native-callkeep#46b9a488f737a002d73327847a8d8190f171754a"
+"react-native-callkeep@https://github.com/react-native-webrtc/react-native-callkeep#fix_outgoing_call_ios":
+  version "3.0.1"
+  resolved "https://github.com/react-native-webrtc/react-native-callkeep#22a3f2d9f8ede5e83f88d9a16c3786efe249ce1f"
 
 react-native-device-info@^2.3.2:
   version "2.3.2"

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,11 @@ export type Events =
   'answerCall' |
   'endCall' |
   'didActivateAudioSession' |
+  'didDeactivateAudioSession' |
   'didDisplayIncomingCall' |
+  'didToggleHoldCallAction' |
+  'didPerformDTMFAction' |
+  'didResetProvider' |
   'didPerformSetMutedCallAction';
 
 type HandleType = 'generic' | 'number' | 'email';
@@ -12,6 +16,9 @@ interface IOptions {
   ios: {
     appName: string,
     imageName?: string,
+    supportsVideo: false,
+    maximumCallGroups: '1',
+    maximumCallsPerCallGroup: '1'
     ringtoneSound?: string,
   },
   android: {
@@ -19,6 +26,8 @@ interface IOptions {
     alertDescription: string,
     cancelButton: string,
     okButton: string,
+    imageName?: string,
+    additionalPermissions: string[],
   },
 }
 
@@ -41,6 +50,10 @@ export default class RNCallKeep {
 
   }
 
+  static hasDefaultPhoneAccount(): boolean {
+
+  }
+
   static displayIncomingCall(
     uuid: string,
     handle: string,
@@ -51,15 +64,19 @@ export default class RNCallKeep {
 
   }
 
-  /**
-   * @description startCall method is available only on iOS.
-  */
   static startCall(
     uuid: string,
     handle: string,
+    contactIdentifier?: string,
     handleType?: HandleType,
     hasVideo?: boolean,
-    contactIdentifier?: string,
+  ) {
+
+  }
+  static updateDisplay(
+    uuid: string,
+    displayName: string,
+    handle: string,
   ) {
 
   }
@@ -68,6 +85,20 @@ export default class RNCallKeep {
      * @description reportConnectedOutgoingCallWithUUID method is available only on iOS.
   */
   static reportConnectedOutgoingCallWithUUID(uuid: string) {
+
+  }
+
+  /**
+     * @description reportConnectedOutgoingCallWithUUID method is available only on iOS.
+  */
+  static reportConnectingOutgoingCallWithUUID(uuid: string): void {
+
+  }
+  static reportEndCallWithUUID(uuid: string, reason: number): void {
+
+  }
+
+  static rejectCall(uuid: string) {
 
   }
 
@@ -93,10 +124,18 @@ export default class RNCallKeep {
 
   }
 
+  static async hasOutgoingCall(): Promise<boolean> {
+
+  }
+
   /**
      * @description setMutedCall method is available only on iOS.
   */
   static setMutedCall(uuid: string, muted: boolean) {
+
+  }
+
+  static setOnHold(uuid: string, held: boolean) {
 
   }
 
@@ -107,16 +146,10 @@ export default class RNCallKeep {
 
   }
 
-  /**
-     * @description setMutedCall method is available only on iOS.
-  */
   static checkIfBusy(): Promise<boolean> {
 
   }
 
-  /**
-     * @description setMutedCall method is available only on iOS.
-  */
   static checkSpeaker(): Promise<boolean> {
 
   }
@@ -128,16 +161,10 @@ export default class RNCallKeep {
 
   }
 
-  /**
-     * @description setAvailable method is available only on Android.
-  */
   static setCurrentCallActive() {
 
   }
 
-  /**
-     * @description setAvailable method is available only on Android.
-  */
   static backToForeground() {
 
   }

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class RNCallKeep {
     if (!isIOS) {
       RNCallKeepModule.answerIncomingCall(uuid);
     }
-  }
+  };
 
   startCall = (uuid, handle, contactIdentifier, handleType = 'number', hasVideo = false ) => {
     if (!isIOS) {
@@ -83,9 +83,8 @@ class RNCallKeep {
     }
   };
 
-  reportEndCallWithUUID = (uuid, reason) => {
+  reportEndCallWithUUID = (uuid, reason) =>
     RNCallKeepModule.reportEndCallWithUUID(uuid, reason);
-  }
 
   /*
    * Android explicitly states we reject a call
@@ -97,15 +96,11 @@ class RNCallKeep {
     } else {
       RNCallKeepModule.endCall(uuid);
     }
-  }
-
-  endCall = (uuid) => {
-    RNCallKeepModule.endCall(uuid);
   };
 
-  endAllCalls = () => {
-    RNCallKeepModule.endAllCalls();
-  };
+  endCall = (uuid) => RNCallKeepModule.endCall(uuid);
+
+  endAllCalls = () => RNCallKeepModule.endAllCalls();
 
   supportConnectionService = () => supportConnectionService;
 
@@ -119,9 +114,7 @@ class RNCallKeep {
     RNCallKeepModule.setMutedCall(uuid, shouldMute);
   };
 
-  sendDTMF = (uuid, key) => {
-    RNCallKeepModule.sendDTMF(uuid, key);
-  };
+  sendDTMF = (uuid, key) => RNCallKeepModule.sendDTMF(uuid, key);
 
   checkIfBusy = () =>
     isIOS
@@ -150,18 +143,18 @@ class RNCallKeep {
     RNCallKeepModule.setCurrentCallActive(callUUID);
   };
 
-  updateDisplay = (uuid, displayName, uri) => {
-    RNCallKeepModule.updateDisplay(uuid, displayName, uri)
-  }
+  updateDisplay = (uuid, displayName, handle) => RNCallKeepModule.updateDisplay(uuid, displayName, handle);
 
-  setOnHold = (uuid, shouldHold) => {
-    RNCallKeepModule.setOnHold(uuid, shouldHold);
-  }
+  setOnHold = (uuid, shouldHold) => RNCallKeepModule.setOnHold(uuid, shouldHold);
 
-  reportUpdatedCall = (uuid, localizedCallerName) =>
-    isIOS
+  // @deprecated
+  reportUpdatedCall = (uuid, localizedCallerName) => {
+    console.warn('RNCallKeep.reportUpdatedCall is deprecarted, use RNCallKeep.updateDisplay instead');
+
+    return isIOS
       ? RNCallKeepModule.reportUpdatedCall(uuid, localizedCallerName)
       : Promise.reject('RNCallKeep.reportUpdatedCall was called from unsupported OS');
+  };
 
   _setupIOS = async (options) => new Promise((resolve, reject) => {
     if (!options.appName) {

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -500,6 +500,7 @@ continueUserActivity:(NSUserActivity *)userActivity
 }
 
 // Update call contact info
+// @deprecated
 RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NSString *)contactIdentifier)
 {
 #ifdef DEBUG


### PR DESCRIPTION
- Fixes #95 
- Deprecate `reportUpdatedCall` which do the same job as `updateDisplay`.
- Update example to allow call to `updateDisplay`