### PR TITLE
Fix outgoing native samsung

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -178,7 +178,12 @@ public class VoiceConnectionService extends ConnectionService {
         outgoingCallConnection.setDialing();
         outgoingCallConnection.setAudioModeIsVoip(true);
         outgoingCallConnection.setCallerDisplayName(displayName, TelecomManager.PRESENTATION_ALLOWED);
-        outgoingCallConnection.setInitialized();
+
+        // ‍️Weirdly on some Samsung phones (A50, S9...) using `setInitialized` will not display the native UI ...
+        // when making a call from the native Phone application. The call will still be displayed correctly without it.
+        if (!Build.MANUFACTURER.equalsIgnoreCase("Samsung")) {
+            outgoingCallConnection.setInitialized();
+        }
 
         HashMap<String, String> extrasMap = this.bundleToMap(extras);
 


### PR DESCRIPTION
On some Samsung phones (with android >= 9), we're expecting an issue when making a call from the native phone application: the ConnectionService UI doesn't appear.

Digging in the code shows that calling `setInitialized` on the connection block the display (without any signifiant log from Android).

But the call to `setInitialized` doesn't appears to be required to display the call correctly via ConnectionService, so we can skip it on Samsung phones.