### PR TITLE
Add more end reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ RNCallKeep.reportEndCallWithUUID(uuid, reason);
     - Remote user ended call: 2
     - Remote user did not answer: 3
     - Call Answered elsewhere: 4
-    - Call declined elsewhere: 5 (on iOS this will map to Remote user ended call if you use the constants)
+    - Call declined elsewhere: 5 (on Android this will map to Remote user ended call if you use the constants)
   - Access reasons as constants
   ```js
   const { CONSTANTS as CK_CONSTANTS, RNCallKeep } from 'react-native-callkeep';

--- a/README.md
+++ b/README.md
@@ -238,14 +238,13 @@ RNCallKeep.reportEndCallWithUUID(uuid, reason);
     - Call failed: 1
     - Remote user ended call: 2
     - Remote user did not answer: 3
-  - `CXCallEndedReason` constants used for iOS. `DisconnectCause` used for Android.
-  - Example enum for reasons
+    - Call Answered elsewhere: 4
+    - Call declined elsewhere: 5 (iOS only)
+  - Access reasons as constants
   ```js
-  END_CALL_REASON = {
-    failed: 1,
-    remoteEnded: 2,
-    unanswered: 3
-  }
+  const { CONSTANTS as CK_CONSTANTS, RNCallKeep } from 'react-native-callkeep';
+
+  RNCallKeep.reportEndCallWithUUID(uuid, CK_CONSTANTS.END_CALL_REASONS.FAILED);
   ```
 
 ### setMutedCall
@@ -471,7 +470,7 @@ RNCallKeep.addEventListener('didPerformDTMFAction', ({ digits, callUUID }) => {
   - The digits that emit the dtmf tone
 - `callUUID` (string)
   - The UUID of the call.
-  
+
 ### - checkReachability
 
 On Android when the application is in background, after a certain delay the OS will close every connection with informing about it.
@@ -611,7 +610,7 @@ class RNCallKeepExample extends React.Component {
 ## Receiving a call when the application is not reachable.
 
 In some case your application can be unreachable :
-- when the user kill the application 
+- when the user kill the application
 - when it's in background since a long time (eg: after ~5mn the os will kill all connections).
 
 To be able to wake up your application to display the incoming call, you can use [https://github.com/ianlin/react-native-voip-push-notification](react-native-voip-push-notification) on iOS or BackgroundMessaging from [react-native-firebase](https://rnfirebase.io/docs/v5.x.x/messaging/receiving-messages#4)-(Optional)(Android-only)-Listen-for-FCM-messages-in-the-background).
@@ -626,12 +625,12 @@ Since iOS 13, you'll have to report the incoming calls that wakes up your applic
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(PKPushType)type withCompletionHandler:(void (^)(void))completion {
   // Process the received push
   [RNVoipPushNotificationManager didReceiveIncomingPushWithPayload:payload forType:(NSString *)type];
-  
+
   // Retrieve information like handle and callerName here
   // NSString *uuid = /* fetch for payload or ... */ [[[NSUUID UUID] UUIDString] lowercaseString];
   // NSString *callerName = @"caller name here";
   // NSString *handle = @"caller number here";
-  
+
   [RNCallKeep reportNewIncomingCall:uuid handle:handle handleType:@"generic" hasVideo:false localizedCallerName:callerName fromPushKit: YES];
 
   completion();

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ const CONSTANTS = {
     REMOTE_ENDED: 2,
     UNANSWERED: 3,
     ANSWERED_ELSEWHERE: 4,
-    DECLINED_ELSEWHERE: 5
+    DECLINED_ELSEWHERE: 5,
+    MISSED: 6
   }
 };
 
@@ -260,6 +261,7 @@ RNCallKeep.reportEndCallWithUUID(uuid, reason);
     - Remote user did not answer: 3
     - Call Answered elsewhere: 4
     - Call declined elsewhere: 5 (on Android this will map to Remote user ended call if you use the constants)
+    - Missed: 6 (on iOS this will map to remote user ended call)
   - Access reasons as constants
   ```js
   const { CONSTANTS as CK_CONSTANTS, RNCallKeep } from 'react-native-callkeep';

--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ RNCallKeep.setup(options);
       Any additional permissions you'd like your app to have at first launch. Can be used to simplify permission flows and avoid
       multiple popups to the user at different times.
 
+## Constants
+
+To make passing the right integer into methods easier, there are constants that are exported from the module.
+
+```
+const CONSTANTS = {
+  END_CALL_REASONS: {
+    FAILED: 1,
+    REMOTE_ENDED: 2,
+    UNANSWERED: 3,
+    ANSWERED_ELSEWHERE: 4,
+    DECLINED_ELSEWHERE: 5
+  }
+};
+
+const { CONSTANTS as CK_CONSTANTS, RNCallKeep } from 'react-native-callkeep';
+
+console.log(CK_CONSTANTS.END_CALL_REASONS.FAILED) // outputs 1
+```
+
 ## Methods
 
 ### setAvailable
@@ -239,7 +259,7 @@ RNCallKeep.reportEndCallWithUUID(uuid, reason);
     - Remote user ended call: 2
     - Remote user did not answer: 3
     - Call Answered elsewhere: 4
-    - Call declined elsewhere: 5 (iOS only)
+    - Call declined elsewhere: 5 (on iOS this will map to Remote user ended call if you use the constants)
   - Access reasons as constants
   ```js
   const { CONSTANTS as CK_CONSTANTS, RNCallKeep } from 'react-native-callkeep';

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -140,6 +140,9 @@ public class VoiceConnection extends Connection {
             case 3:
                 setDisconnected(new DisconnectCause(DisconnectCause.BUSY));
                 break;
+            case 4:
+                setDisconnected(new DisconnectCause(DisconnectCause.ANSWERED_ELSEWHERE));
+                break;
             default:
                 break;
         }

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -135,6 +135,7 @@ public class VoiceConnection extends Connection {
                 setDisconnected(new DisconnectCause(DisconnectCause.ERROR));
                 break;
             case 2:
+            case 5:
                 setDisconnected(new DisconnectCause(DisconnectCause.REMOTE));
                 break;
             case 3:
@@ -142,6 +143,9 @@ public class VoiceConnection extends Connection {
                 break;
             case 4:
                 setDisconnected(new DisconnectCause(DisconnectCause.ANSWERED_ELSEWHERE));
+                break;
+            case 6:
+                setDisconnected(new DisconnectCause(DisconnectCause.MISSED));
                 break;
             default:
                 break;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,18 @@ const RNCallKeepModule = NativeModules.RNCallKeep;
 const isIOS = Platform.OS === 'ios';
 const supportConnectionService = !isIOS && Platform.Version >= 23;
 
+const CONSTANTS = {
+  END_CALL_REASONS: {
+    FAILED: 1,
+    REMOTE_ENDED: 2,
+    UNANSWERED: 3,
+    ANSWERED_ELSEWHERE: 4,
+    DECLINED_ELSEWHERE: 5 //only works on ios
+  }
+};
+
+export { CONSTANTS };
+
 class RNCallKeep {
 
   constructor() {

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ const CONSTANTS = {
     REMOTE_ENDED: 2,
     UNANSWERED: 3,
     ANSWERED_ELSEWHERE: 4,
-    DECLINED_ELSEWHERE: isIOS ? 5 : 2 // make declined elsewhere link to "Remote ended" on android because that's kinda true
-  }
+    DECLINED_ELSEWHERE: isIOS ? 5 : 2, // make declined elsewhere link to "Remote ended" on android because that's kinda true
+    MISSED: isIOS ? 2 : 6  }
 };
 
 export { CONSTANTS };

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const CONSTANTS = {
     REMOTE_ENDED: 2,
     UNANSWERED: 3,
     ANSWERED_ELSEWHERE: 4,
-    DECLINED_ELSEWHERE: 5 //only works on ios
+    DECLINED_ELSEWHERE: isIOS ? 2 : 5 // make declined elsewhere link to "Remote ended" because that's kinda true
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const CONSTANTS = {
     REMOTE_ENDED: 2,
     UNANSWERED: 3,
     ANSWERED_ELSEWHERE: 4,
-    DECLINED_ELSEWHERE: isIOS ? 2 : 5 // make declined elsewhere link to "Remote ended" because that's kinda true
+    DECLINED_ELSEWHERE: isIOS ? 5 : 2 // make declined elsewhere link to "Remote ended" on android because that's kinda true
   }
 };
 

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -245,6 +245,12 @@ RCT_EXPORT_METHOD(reportEndCallWithUUID:(NSString *)uuidString :(int)reason)
         case CXCallEndedReasonUnanswered:
             [self.callKeepProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonUnanswered];
             break;
+        case CXCallEndedReasonAnsweredElsewhere:
+            [self.callKeepProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonAnsweredElsewhere];
+            break;
+        case CXCallEndedReasonDeclinedElsewhere:
+            [self.callKeepProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonDeclinedElsewhere];
+            break;
         default:
             break;
     }

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -236,19 +236,20 @@ RCT_EXPORT_METHOD(reportEndCallWithUUID:(NSString *)uuidString :(int)reason)
 #endif
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
     switch (reason) {
-        case CXCallEndedReasonFailed:
+        case 1:
             [self.callKeepProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonFailed];
             break;
-        case CXCallEndedReasonRemoteEnded:
+        case 2:
+        case 6:
             [self.callKeepProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonRemoteEnded];
             break;
-        case CXCallEndedReasonUnanswered:
+        case 3:
             [self.callKeepProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonUnanswered];
             break;
-        case CXCallEndedReasonAnsweredElsewhere:
+        case 4:
             [self.callKeepProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonAnsweredElsewhere];
             break;
-        case CXCallEndedReasonDeclinedElsewhere:
+        case 5:
             [self.callKeepProvider reportCallWithUUID:uuid endedAtDate:[NSDate date] reason:CXCallEndedReasonDeclinedElsewhere];
             break;
         default:


### PR DESCRIPTION
iOS allows 2 more end reasons

call answered elsewhere and call declined elsewhere. add support for these two reasons. Android has quite a few other reasons available but I haven't added them because ios just doesn't support them. Android doesn't support declined elsewhere but I've mapped that in the new constants object to remote ended because technically (in the context of that endpoint) it did. 