### PR TITLE
Add a troubleshooting note on using a valid uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,9 @@ Since iOS 13, you'll have to report the incoming calls that wakes up your applic
 adb logcat *:S RNCallKeepModule:V
 ```
 
+## Troubleshooting
+- Ensure that you use a valid `uuid` using the uuid library as shown in the examples (not a custom string), otherwise the incoming call screen will never be shown on iOS.
+
 ## Contributing
 
 Any pull request, issue report and suggestion are highly welcome!

--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ adb logcat *:S RNCallKeepModule:V
 ```
 
 ## Troubleshooting
-- Ensure that you use a valid `uuid` using the uuid library as shown in the examples (not a custom string), otherwise the incoming call screen will never be shown on iOS.
+- Ensure that you construct a valid `uuid` by importing the `uuid` library and running `uuid.v4()` as shown in the examples. If you don't do this and use a custom string, the incoming call screen will never be shown on iOS.
 
 ## Contributing
 


### PR DESCRIPTION
Was stuck for some time trying to figure out why the incoming call wasn't being received and it turned out, it was simply because I had supplied an invalid `uuid`.  The `didDisplayIncomingCall` method also returns without any errors, so there's no explanation for why the screen didn't show up. Might be great if the library threw an error in `didDisplayIncomingCall` if an invalid `uuid` is supplied.