### PR TITLE
readme/doc: fix typo and remove duplicated `endAllCalls` method sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ RNCallKeep.updateDisplay(uuid, displayName, handle)
 
 ### endCall
 
-When you finish an incoming/outgoing call.
+When finish an incoming/outgoing call.  
+(When user actively chooses to end the call from your app's UI.)
 
 ```js
 RNCallKeep.endCall(uuid);
@@ -248,7 +249,9 @@ RNCallKeep.rejectCall(uuid);
 
 ### reportEndCallWithUUID
 
-Report that the call ended without the user initiating
+Report that the call ended without the user initiating.  
+(Not ended by user, is usually due to the following reasons)
+
 
 ```js
 RNCallKeep.reportEndCallWithUUID(uuid, reason);

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ RNCallKeep.endCall(uuid);
 
 ### endAllCalls
 
-End all ongoing connections.
+End all ongoing calls.
 
 ```js
 RNCallKeep.endAllCalls();
@@ -294,14 +294,6 @@ RNCallKeep.setOnHold(uuid, true)
 - `uuid`: string
   - uuid of the current call.
 - `hold`: boolean
-
-### endAllCalls
-
-End all calls that have been started on the device.
-
-```js
-RNCallKeep.endAllCalls();
-```
 
 ### checkIfBusy
 
@@ -463,7 +455,7 @@ RNCallKeep.addEventListener('didDisplayIncomingCall', ({ error, callUUID, handle
 - `fromPushKit` (string)
   - `1` (call triggered from PushKit)
   - `0` (call not triggered from PushKit)
-- `didDisplayIncomingCall` (object)
+- `payload` (object)
   - VOIP push payload.
 
 ### - didPerformSetMutedCallAction


### PR DESCRIPTION
* fix typo
* remove duplicated `endAllCalls` method sections
* make endCall related api usage description more clearer