### PR TITLE
Proof of concept to handle issue with JS not initialized on start to fix #107

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,26 @@ RNCallKeep.addEventListener('didPerformDTMFAction', ({ digits, callUUID }) => {
 - `callUUID` (string)
   - The UUID of the call.
 
+### - didLoadWithEvents
+
+iOS only.
+
+Called as soon as JS context initializes if there were some actions performed by user before JS context has been created.
+
+Since iOS 13, you must display incoming call on receiving PushKit push notification. But if app was killed, it takes some time to create JS context. If user answers the call (or ends it) before JS context has been initialized, user actions will be passed as events array of this event. Similar situation can happen if user would like to start a call from Recents or similar iOS app, assuming that your app was in killed state.
+
+```js
+RNCallKeep.addEventListener('didLoadWithEvents', (events) => {
+  // see example usage in https://github.com/react-native-webrtc/react-native-callkeep/pull/169
+});
+```
+
+- `events` Array
+  - `name`: string
+    Native event name like: `RNCallKeepPerformAnswerCallAction`
+  - `data`: object
+    Object with data passed together with specific event so it can be handled in the same way like original event, for example `({ callUUID })` for `answerCall` event if `name` is `RNCallKeepPerformAnswerCallAction`
+
 ### - checkReachability
 
 On Android when the application is in background, after a certain delay the OS will close every connection with informing about it.

--- a/actions.js
+++ b/actions.js
@@ -14,6 +14,7 @@ const RNCallKeepDidToggleHoldAction = 'RNCallKeepDidToggleHoldAction';
 const RNCallKeepDidPerformDTMFAction = 'RNCallKeepDidPerformDTMFAction';
 const RNCallKeepProviderReset = 'RNCallKeepProviderReset';
 const RNCallKeepCheckReachability = 'RNCallKeepCheckReachability';
+const RNCallKeepDidLoadWithEvents = 'RNCallKeepDidLoadWithEvents';
 const isIOS = Platform.OS === 'ios';
 
 const didReceiveStartCallAction = handler => {
@@ -55,6 +56,9 @@ const didResetProvider = handler =>
 const checkReachability = handler =>
   eventEmitter.addListener(RNCallKeepCheckReachability, handler);
 
+const didLoadWithEvents = handler =>
+  eventEmitter.addListener(RNCallKeepDidLoadWithEvents, handler);
+
 export const listeners = {
   didReceiveStartCallAction,
   answerCall,
@@ -67,4 +71,5 @@ export const listeners = {
   didPerformDTMFAction,
   didResetProvider,
   checkReachability,
+  didLoadWithEvents
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,8 @@ export type Events =
   'didPerformDTMFAction' |
   'didResetProvider' |
   'checkReachability' |
-  'didPerformSetMutedCallAction';
+  'didPerformSetMutedCallAction' |
+  'didLoadWithEvents';
 
 type HandleType = 'generic' | 'number' | 'email';
 

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -547,7 +547,7 @@ continueUserActivity:(NSUserActivity *)userActivity
         };
 
         RNCallKeep *callKeep = [RNCallKeep allocWithZone: nil];
-        [callKeep handleStartCallNotification: userInfo];
+        [callKeep sendEventWithNameWrapper:RNCallKeepDidReceiveStartCallAction body:userInfo];
         return YES;
     }
     return NO;

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -33,11 +33,15 @@ static NSString *const RNCallKeepPerformPlayDTMFCallAction = @"RNCallKeepDidPerf
 static NSString *const RNCallKeepDidToggleHoldAction = @"RNCallKeepDidToggleHoldAction";
 static NSString *const RNCallKeepProviderReset = @"RNCallKeepProviderReset";
 static NSString *const RNCallKeepCheckReachability = @"RNCallKeepCheckReachability";
+static NSString *const RNCallKeepDidLoadWithEvents = @"RNCallKeepDidLoadWithEvents";
 
 @implementation RNCallKeep
 {
     NSOperatingSystemVersion _version;
     BOOL _isStartCallActionEventListenerAdded;
+    bool _hasListeners;
+    NSMutableArray *_delayedEvents;
+   
 }
 
 static CXProvider* sharedProvider;
@@ -52,6 +56,7 @@ RCT_EXPORT_MODULE()
 #endif
     if (self = [super init]) {
         _isStartCallActionEventListenerAdded = NO;
+        _delayedEvents = [NSMutableArray array];
     }
     return self;
 }
@@ -92,8 +97,34 @@ RCT_EXPORT_MODULE()
         RNCallKeepPerformPlayDTMFCallAction,
         RNCallKeepDidToggleHoldAction,
         RNCallKeepProviderReset,
-        RNCallKeepCheckReachability
+        RNCallKeepCheckReachability,
+        RNCallKeepDidLoadWithEvents
     ];
+}
+
+- (void)startObserving
+{
+    _hasListeners = YES;
+    if ([_delayedEvents count] > 0) {
+        [self sendEventWithName:RNCallKeepDidLoadWithEvents body:_delayedEvents];
+    }
+}
+
+- (void)stopObserving
+{
+    _hasListeners = FALSE;
+}
+
+- (void)sendEventWithNameWrapper:(NSString *)name body:(id)body {
+    if (_hasListeners) {
+        [self sendEventWithName:name body:body];
+    } else {
+        NSDictionary *dictionary = @{
+            @"name": name,
+            @"data": body
+        };
+        [_delayedEvents addObject:dictionary];
+    }
 }
 
 + (void)initCallKitProvider {
@@ -351,7 +382,7 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
     [RNCallKeep initCallKitProvider];
     [sharedProvider reportNewIncomingCallWithUUID:uuid update:callUpdate completion:^(NSError * _Nullable error) {
         RNCallKeep *callKeep = [RNCallKeep allocWithZone: nil];
-        [callKeep sendEventWithName:RNCallKeepDidDisplayIncomingCall body:@{ @"error": error ? error.localizedDescription : @"", @"callUUID": uuidString, @"handle": handle, @"localizedCallerName": localizedCallerName, @"hasVideo": hasVideo ? @"1" : @"0", @"fromPushKit": fromPushKit ? @"1" : @"0" }];
+        [callKeep sendEventWithNameWrapper:RNCallKeepDidDisplayIncomingCall body:@{ @"error": error ? error.localizedDescription : @"", @"callUUID": uuidString, @"handle": handle, @"localizedCallerName": localizedCallerName, @"hasVideo": hasVideo ? @"1" : @"0", @"fromPushKit": fromPushKit ? @"1" : @"0" }];
         if (error == nil) {
             // Workaround per https://forums.developer.apple.com/message/169511
             if ([callKeep lessThanIos10_2]) {
@@ -541,7 +572,7 @@ continueUserActivity:(NSUserActivity *)userActivity
     }
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
     dispatch_after(popTime, dispatch_get_main_queue(), ^{
-        [self sendEventWithName:RNCallKeepDidReceiveStartCallAction body:userInfo];
+        [self sendEventWithNameWrapper:RNCallKeepDidReceiveStartCallAction body:userInfo];
     });
 }
 
@@ -553,7 +584,7 @@ continueUserActivity:(NSUserActivity *)userActivity
 #endif
     //this means something big changed, so tell the JS. The JS should
     //probably respond by hanging up all calls.
-    [self sendEventWithName:RNCallKeepProviderReset body:nil];
+    [self sendEventWithNameWrapper:RNCallKeepProviderReset body:nil];
 }
 
 // Starting outgoing call
@@ -565,7 +596,7 @@ continueUserActivity:(NSUserActivity *)userActivity
     //do this first, audio sessions are flakey
     [self configureAudioSession];
     //tell the JS to actually make the call
-    [self sendEventWithName:RNCallKeepDidReceiveStartCallAction body:@{ @"callUUID": [action.callUUID.UUIDString lowercaseString], @"handle": action.handle.value }];
+    [self sendEventWithNameWrapper:RNCallKeepDidReceiveStartCallAction body:@{ @"callUUID": [action.callUUID.UUIDString lowercaseString], @"handle": action.handle.value }];
     [action fulfill];
 }
 
@@ -590,7 +621,7 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
     NSLog(@"[RNCallKeep][CXProviderDelegate][provider:performAnswerCallAction]");
 #endif
     [self configureAudioSession];
-    [self sendEventWithName:RNCallKeepPerformAnswerCallAction body:@{ @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
+    [self sendEventWithNameWrapper:RNCallKeepPerformAnswerCallAction body:@{ @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
     [action fulfill];
 }
 
@@ -600,7 +631,7 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][CXProviderDelegate][provider:performEndCallAction]");
 #endif
-    [self sendEventWithName:RNCallKeepPerformEndCallAction body:@{ @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
+    [self sendEventWithNameWrapper:RNCallKeepPerformEndCallAction body:@{ @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
     [action fulfill];
 }
 
@@ -610,7 +641,7 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
     NSLog(@"[RNCallKeep][CXProviderDelegate][provider:performSetHeldCallAction]");
 #endif
 
-    [self sendEventWithName:RNCallKeepDidToggleHoldAction body:@{ @"hold": @(action.onHold), @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
+    [self sendEventWithNameWrapper:RNCallKeepDidToggleHoldAction body:@{ @"hold": @(action.onHold), @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
     [action fulfill];
 }
 
@@ -618,7 +649,7 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][CXProviderDelegate][provider:performPlayDTMFCallAction]");
 #endif
-    [self sendEventWithName:RNCallKeepPerformPlayDTMFCallAction body:@{ @"digits": action.digits, @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
+    [self sendEventWithNameWrapper:RNCallKeepPerformPlayDTMFCallAction body:@{ @"digits": action.digits, @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
     [action fulfill];
 }
 
@@ -628,7 +659,7 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
     NSLog(@"[RNCallKeep][CXProviderDelegate][provider:performSetMutedCallAction]");
 #endif
 
-    [self sendEventWithName:RNCallKeepDidPerformSetMutedCallAction body:@{ @"muted": @(action.muted), @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
+    [self sendEventWithNameWrapper:RNCallKeepDidPerformSetMutedCallAction body:@{ @"muted": @(action.muted), @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
     [action fulfill];
 }
 
@@ -652,7 +683,7 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
     [[NSNotificationCenter defaultCenter] postNotificationName:AVAudioSessionInterruptionNotification object:nil userInfo:userInfo];
 
     [self configureAudioSession];
-    [self sendEventWithName:RNCallKeepDidActivateAudioSession body:nil];
+    [self sendEventWithNameWrapper:RNCallKeepDidActivateAudioSession body:nil];
 }
 
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession *)audioSession
@@ -660,7 +691,7 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][CXProviderDelegate][provider:didDeactivateAudioSession]");
 #endif
-    [self sendEventWithName:RNCallKeepDidDeactivateAudioSession body:nil];
+    [self sendEventWithNameWrapper:RNCallKeepDidDeactivateAudioSession body:nil];
 }
 
 @end


### PR DESCRIPTION
Proof of concept to handle issue with JS not initialized on start to fix #107

Described in details here: https://github.com/react-native-webrtc/react-native-callkeep/issues/107#issuecomment-581845376

Example usage:
```
import { each, compact, last, get } from 'lodash';

RNCallKeep.addEventListener(
  'didLoadWithEvents',
  this.onDidLoadWithNativeEvents
);

onDidLoadWithNativeEvents(events) {
  const validEvents = compact(events);
  let callDataToAdd = null;
  let callDataToAnswer = null;
  let callDataToReject = null;
  let callDataToInitiateCall = null;
  each(compact(validEvents), event => {
    const { name, data } = event;
    if (name === 'RNCallKeepDidDisplayIncomingCall') {
      callDataToAdd = data;
      callDataToAnswer = null;
      callDataToReject = null;
    }
    if (name === 'RNCallKeepPerformAnswerCallAction') {
      callDataToReject = null;
      callDataToAnswer = data;
    }
    if (name === 'RNCallKeepPerformEndCallAction') {
      callDataToAnswer = null;
      callDataToReject = data;
    }
  });

  const lastEventName = get(last(validEvents), 'name');
  if (lastEventName === 'RNCallKeepDidReceiveStartCallAction') {
    callDataToInitiateCall = get(last(validEvents), 'data');
    callDataToAnswer = null;
    if (!callDataToReject) {
      callDataToAdd = null;
    }
  }

  if (callDataToAdd) {
    this.onDisplayIncomingCall(callDataToAdd);
    if (callDataToReject) {
      this.onEndCall(callDataToReject);
    }
    if (callDataToAnswer) {
      this.onAnswerCall(callDataToAnswer);
    }
  }
  if (callDataToInitiateCall) {
    this.onStartCall(callDataToAnswer);
  }
}
```