### PR TITLE
Fix Video button not working in iOS Lock Screen

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -413,7 +413,12 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
     providerConfiguration.supportsVideo = YES;
     providerConfiguration.maximumCallGroups = 3;
     providerConfiguration.maximumCallsPerCallGroup = 1;
-    providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypePhoneNumber], nil];
+    if(settings[@"handleType"]){
+        int _handleType = [RNCallKeep getHandleType:settings[@"handleType"]];
+        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:_handleType], nil];
+    }else{
+        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypeGeneric], nil];
+    }
     if (settings[@"supportsVideo"]) {
         providerConfiguration.supportsVideo = [settings[@"supportsVideo"] boolValue];
     }


### PR DESCRIPTION
When answering the call, if iOS user is in a lockscreen and then want to press video button to go to the app. The current behavior is that button just do nothing. The issue related to the way we hardcoded the handleType when set up "providerConfiguration". I tried to make it dynamic as much as possible via user's settings and the default value should be CXHandleTypeGeneric because our example for reportingNewIncomingCall using generic as well.