### PR TITLE
New Method Check if Active Call with UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ RNCallKeep.setCurrentCallActive(uuid);
 - `uuid`: string
   - The `uuid` used for `startCall` or `displayIncomingCall`
 
+### isCallActive
+_This feature is available only on IOS._
+
+Returns true if the UUID passed matches an existing and answered call. 
+This will return true ONLY if the call exists and the user has already answered the call. It will return false 
+if the call does not exist or has not been answered. This is exposed to both React Native and Native sides.
+This was exposed so a call can be canceled if ringing and the user answered on a different device.
+
+```js
+RNCallKeep.isCallActive(uuid);
+```
+
+- `uuid`: string
+  - The `uuid` used for `startCall` or `displayIncomingCall`
+
 ### displayIncomingCall
 
 Display system UI for incoming calls

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,11 +81,6 @@ export default class RNCallKeep {
   ) {
 
   }
-  static isCallActive(
-      uuid: string,
-  ){
-
-  }
 
   /**
      * @description reportConnectedOutgoingCallWithUUID method is available only on iOS.
@@ -119,7 +114,9 @@ export default class RNCallKeep {
   static setReachable() {
 
   }
+  static isCallActive(uuid: string): void{
 
+  }
   /**
      * @description supportConnectionService method is available only on Android.
   */

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,9 +81,7 @@ export default class RNCallKeep {
   ) {
 
   }
-
-  // @ts-ignore
-    static isCallActive(
+  static isCallActive(
       uuid: string,
   ){
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,7 +114,7 @@ export default class RNCallKeep {
   static setReachable() {
 
   }
-  static isCallActive(uuid: string): void{
+  static isCallActive(uuid: string): Promise<boolean> {
 
   }
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,13 @@ export default class RNCallKeep {
 
   }
 
+  // @ts-ignore
+    static isCallActive(
+      uuid: string,
+  ){
+
+  }
+
   /**
      * @description reportConnectedOutgoingCallWithUUID method is available only on iOS.
   */

--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ class RNCallKeep {
     return;
   };
 
+  isCallActive = (uuid) => {
+      return RNCallKeepModule.isCallActive(uuid);
+  }
+
   displayIncomingCall = (uuid, handle, localizedCallerName, handleType = 'number', hasVideo = false) => {
     if (!isIOS) {
       RNCallKeepModule.displayIncomingCall(uuid, handle, localizedCallerName);

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ class RNCallKeep {
     }
   };
 
-  isCallActive = async(uuid) => RNCallKeepModule.isCallActive(uuid);
+  isCallActive = async(uuid) => await RNCallKeepModule.isCallActive(uuid);
 
   endCall = (uuid) => RNCallKeepModule.endCall(uuid);
 

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ class RNCallKeep {
     }
   };
 
-  isCallActive = (uuid) => RNCallKeepModule.isCallActive(uuid);
+  isCallActive = async(uuid) => RNCallKeepModule.isCallActive(uuid);
 
   endCall = (uuid) => RNCallKeepModule.endCall(uuid);
 

--- a/index.js
+++ b/index.js
@@ -56,10 +56,6 @@ class RNCallKeep {
     return;
   };
 
-  isCallActive = (uuid) => {
-      return RNCallKeepModule.isCallActive(uuid);
-  }
-
   displayIncomingCall = (uuid, handle, localizedCallerName, handleType = 'number', hasVideo = false) => {
     if (!isIOS) {
       RNCallKeepModule.displayIncomingCall(uuid, handle, localizedCallerName);
@@ -111,6 +107,8 @@ class RNCallKeep {
       RNCallKeepModule.endCall(uuid);
     }
   };
+
+  isCallActive = (uuid) => RNCallKeepModule.isCallActive(uuid);
 
   endCall = (uuid) => RNCallKeepModule.endCall(uuid);
 

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -15,7 +15,6 @@
 #import <React/RCTEventEmitter.h>
 
 @interface RNCallKeep : RCTEventEmitter <CXProviderDelegate>
-
 @property (nonatomic, strong) CXCallController *callKeepCallController;
 @property (nonatomic, strong) CXProvider *callKeepProvider;
 
@@ -37,4 +36,7 @@ continueUserActivity:(NSUserActivity *)userActivity
 
 + (void)endCallWithUUID:(NSString *)uuidString
                  reason:(int)reason;
+
++ (BOOL)checkIfActiveCall:(NSString *)uuidString;
+
 @end

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -38,6 +38,6 @@ continueUserActivity:(NSUserActivity *)userActivity
 + (void)endCallWithUUID:(NSString *)uuidString
                  reason:(int)reason;
 
-+ (BOOL)checkIfActiveCall:(NSString *)uuidString;
++ (BOOL)isCallActive:(NSString *)uuidString;
 
 @end

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -15,6 +15,7 @@
 #import <React/RCTEventEmitter.h>
 
 @interface RNCallKeep : RCTEventEmitter <CXProviderDelegate>
+
 @property (nonatomic, strong) CXCallController *callKeepCallController;
 @property (nonatomic, strong) CXProvider *callKeepProvider;
 

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -304,6 +304,20 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
     }];
 }
 
++ (BOOL)checkIfActiveCall:(NSString *)uuidString
+{
+    CXCallObserver *callObserver = [[CXCallObserver alloc] init];
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+
+    for(CXCall *call in callObserver.calls){
+        NSLog(@"Connected: %d", [call.UUID isEqual:uuid]);
+        if([call.UUID isEqual:[[NSUUID alloc] initWithUUIDString:uuidString]] && !call.hasConnected){
+            return true;
+        }
+    }
+    return false;
+}
+
 + (void)endCallWithUUID:(NSString *)uuidString
                  reason:(int)reason
 {

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -273,6 +273,15 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
     [self requestTransaction:transaction];
 }
 
+RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKeep][sendDTMF] key = %@", key);
+#endif
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+    [RNCallKeep isCallActive: uuidString]
+}
+
 - (void)requestTransaction:(CXTransaction *)transaction
 {
 #ifdef DEBUG

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -304,13 +304,13 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
     }];
 }
 
-+ (BOOL)checkIfActiveCall:(NSString *)uuidString
++ (BOOL)isCallActive:(NSString *)uuidString
 {
     CXCallObserver *callObserver = [[CXCallObserver alloc] init];
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
 
     for(CXCall *call in callObserver.calls){
-        NSLog(@"Connected: %d", [call.UUID isEqual:uuid]);
+        NSLog(@"[RNCallKeep] isCallActive %@ %d ?", call.UUID, [call.UUID isEqual:uuid]);
         if([call.UUID isEqual:[[NSUUID alloc] initWithUUIDString:uuidString]] && !call.hasConnected){
             return true;
         }

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -278,7 +278,6 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][isCallActive] uuid = %@", uuidString);
 #endif
-    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
     [RNCallKeep isCallActive: uuidString];
 }
 

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -276,10 +276,10 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
 RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
 {
 #ifdef DEBUG
-    NSLog(@"[RNCallKeep][sendDTMF] key = %@", key);
+    NSLog(@"[RNCallKeep][isCallActive] uuid = %@", uuidString);
 #endif
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
-    [RNCallKeep isCallActive: uuidString]
+    [RNCallKeep isCallActive: uuidString];
 }
 
 - (void)requestTransaction:(CXTransaction *)transaction


### PR DESCRIPTION
IOS Only similar to checkIfBusy, allows the user to check if the specified call UUID is the active call. 

This is available on both the React Native and IOS Native side. 

I added this due to a need to cancel the incoming call UI via Push notification. This should be feasible on Android however IOS requires notifications to be handled in the background in order for the incoming call UI to be canceled.