### PR TITLE
ios: support additional options pass from js

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,15 @@ const options = {
 RNCallKeep.hasDefaultPhoneAccount(options);
 ```
 
+### backToForeground
+_This feature is available only on Android._
+
+Use this to display the application in foreground if the application was in background state. 
+This method will open the application if it was closed.
+
+```js
+RNCallKeep.backToForeground();
+```
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ RNCallKeep.setCurrentCallActive(uuid);
 - `uuid`: string
   - The `uuid` used for `startCall` or `displayIncomingCall`
 
+### isCallActive
+_This feature is available only on IOS._
+
+Returns true if the UUID passed matches an existing and answered call. 
+This will return true ONLY if the call exists and the user has already answered the call. It will return false 
+if the call does not exist or has not been answered. This is exposed to both React Native and Native sides.
+This was exposed so a call can be canceled if ringing and the user answered on a different device.
+
+```js
+RNCallKeep.isCallActive(uuid);
+```
+
+- `uuid`: string
+  - The `uuid` used for `startCall` or `displayIncomingCall`
+
 ### displayIncomingCall
 
 Display system UI for incoming calls

--- a/README.md
+++ b/README.md
@@ -673,9 +673,7 @@ Since iOS 13, you'll have to report the incoming calls that wakes up your applic
   // NSString *handle = @"caller number here";
   // NSDictionary *extra = [payload.dictionaryPayload valueForKeyPath:@"custom.path.to.data"]; /* use this to pass any special data (ie. from your notification) down to RN. Can also be `nil` */
 
-  [RNCallKeep reportNewIncomingCall:uuid handle:handle handleType:@"generic" hasVideo:false localizedCallerName:callerName fromPushKit: YES payload:extra];
-
-  completion();
+  [RNCallKeep reportNewIncomingCall:uuid handle:handle handleType:@"generic" hasVideo:false localizedCallerName:callerName fromPushKit: YES payload:extra withCompletionHandler:completion];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ RNCallKeep.displayIncomingCall(uuid, handle, localizedCallerName);
 - `hasVideo`: boolean (optional, iOS only)
   - `false` (default)
   - `true` (you know... when not false)
+- `options`: object (optional)
+  - `ios`: object
+    - `supportsHolding`: boolean (optional, default true)
+    - `supportsDTMF`: boolean (optional, default true)
+    - `supportsGrouping`: boolean (optional, default true)
+    - `supportsUngrouping`: boolean (optional, default true)
+  - `android`: object (currently no-op)
 
 ### answerIncomingCall
 _This feature is available only on Android._
@@ -230,6 +237,14 @@ RNCallKeep.updateDisplay(uuid, displayName, handle)
   - Name of the caller to be displayed on the native UI
 - `handle`: string
   - Phone number of the caller
+- `options`: object (optional)
+  - `ios`: object
+    - `hasVideo`: boolean (optional)
+    - `supportsHolding`: boolean (optional)
+    - `supportsDTMF`: boolean (optional)
+    - `supportsGrouping`: boolean (optional)
+    - `supportsUngrouping`: boolean (optional)
+  - `android`: object (currently no-op)
 
 ### endCall
 

--- a/android/src/main/java/io/wazo/callkeep/Constants.java
+++ b/android/src/main/java/io/wazo/callkeep/Constants.java
@@ -1,0 +1,19 @@
+package io.wazo.callkeep;
+
+public class Constants {
+    public static final String ACTION_ANSWER_CALL = "ACTION_ANSWER_CALL";
+    public static final String ACTION_AUDIO_SESSION = "ACTION_AUDIO_SESSION";
+    public static final String ACTION_CHECK_REACHABILITY = "ACTION_CHECK_REACHABILITY";
+    public static final String ACTION_DTMF_TONE = "ACTION_DTMF_TONE";
+    public static final String ACTION_END_CALL = "ACTION_END_CALL";
+    public static final String ACTION_HOLD_CALL = "ACTION_HOLD_CALL";
+    public static final String ACTION_MUTE_CALL = "ACTION_MUTE_CALL";
+    public static final String ACTION_ONGOING_CALL = "ACTION_ONGOING_CALL";
+    public static final String ACTION_UNHOLD_CALL = "ACTION_UNHOLD_CALL";
+    public static final String ACTION_UNMUTE_CALL = "ACTION_UNMUTE_CALL";
+    public static final String ACTION_WAKE_APP = "ACTION_WAKE_APP";
+
+    public static final String EXTRA_CALL_NUMBER = "EXTRA_CALL_NUMBER";
+    public static final String EXTRA_CALL_UUID = "EXTRA_CALL_UUID";
+    public static final String EXTRA_CALLER_NAME = "EXTRA_CALLER_NAME";
+}

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepBackgroundMessagingService.java
@@ -26,9 +26,9 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
 
-import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALLER_NAME;
-import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALL_NUMBER;
-import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALL_UUID;
+import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
+import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
+import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
 
 import javax.annotation.Nullable;
 

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -55,6 +55,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
 import java.lang.reflect.Array;
@@ -67,25 +68,25 @@ import java.util.ResourceBundle;
 
 import static android.support.v4.app.ActivityCompat.requestPermissions;
 
+import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
+import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
+import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
+import static io.wazo.callkeep.Constants.ACTION_END_CALL;
+import static io.wazo.callkeep.Constants.ACTION_ANSWER_CALL;
+import static io.wazo.callkeep.Constants.ACTION_MUTE_CALL;
+import static io.wazo.callkeep.Constants.ACTION_UNMUTE_CALL;
+import static io.wazo.callkeep.Constants.ACTION_DTMF_TONE;
+import static io.wazo.callkeep.Constants.ACTION_HOLD_CALL;
+import static io.wazo.callkeep.Constants.ACTION_UNHOLD_CALL;
+import static io.wazo.callkeep.Constants.ACTION_ONGOING_CALL;
+import static io.wazo.callkeep.Constants.ACTION_AUDIO_SESSION;
+import static io.wazo.callkeep.Constants.ACTION_CHECK_REACHABILITY;
+import static io.wazo.callkeep.Constants.ACTION_WAKE_APP;
+
 // @see https://github.com/kbagchiGWC/voice-quickstart-android/blob/9a2aff7fbe0d0a5ae9457b48e9ad408740dfb968/exampleConnectionService/src/main/java/com/twilio/voice/examples/connectionservice/VoiceConnectionServiceActivity.java
 public class RNCallKeepModule extends ReactContextBaseJavaModule {
     public static final int REQUEST_READ_PHONE_STATE = 1337;
     public static final int REQUEST_REGISTER_CALL_PROVIDER = 394859;
-
-    public static final String CHECKING_PERMS = "CHECKING_PERMS";
-    public static final String EXTRA_CALLER_NAME = "EXTRA_CALLER_NAME";
-    public static final String EXTRA_CALL_UUID = "EXTRA_CALL_UUID";
-    public static final String EXTRA_CALL_NUMBER = "EXTRA_CALL_NUMBER";
-    public static final String ACTION_END_CALL = "ACTION_END_CALL";
-    public static final String ACTION_ANSWER_CALL = "ACTION_ANSWER_CALL";
-    public static final String ACTION_MUTE_CALL = "ACTION_MUTE_CALL";
-    public static final String ACTION_UNMUTE_CALL = "ACTION_UNMUTE_CALL";
-    public static final String ACTION_DTMF_TONE = "ACTION_DTMF_TONE";
-    public static final String ACTION_HOLD_CALL = "ACTION_HOLD_CALL";
-    public static final String ACTION_UNHOLD_CALL = "ACTION_UNHOLD_CALL";
-    public static final String ACTION_ONGOING_CALL = "ACTION_ONGOING_CALL";
-    public static final String ACTION_AUDIO_SESSION = "ACTION_AUDIO_SESSION";
-    public static final String ACTION_CHECK_REACHABILITY = "ACTION_CHECK_REACHABILITY";
 
     private static final String E_ACTIVITY_DOES_NOT_EXIST = "E_ACTIVITY_DOES_NOT_EXIST";
     private static final String REACT_NATIVE_MODULE_NAME = "RNCallKeep";
@@ -122,6 +123,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
             this.registerPhoneAccount(this.getAppContext());
             voiceBroadcastReceiver = new VoiceBroadcastReceiver();
             registerReceiver();
+            VoiceConnectionService.setPhoneAccountHandle(handle);
             VoiceConnectionService.setAvailable(true);
         }
     }
@@ -567,6 +569,18 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
                     break;
                 case ACTION_CHECK_REACHABILITY:
                     sendEventToJS("RNCallKeepCheckReachability", null);
+                    break;
+                case ACTION_WAKE_APP:
+                    Intent headlessIntent = new Intent(reactContext, RNCallKeepBackgroundMessagingService.class);
+                    headlessIntent.putExtra("callUUID", attributeMap.get(EXTRA_CALL_UUID));
+                    headlessIntent.putExtra("name", attributeMap.get(EXTRA_CALLER_NAME));
+                    headlessIntent.putExtra("handle", attributeMap.get(EXTRA_CALL_NUMBER));
+                    Log.d(TAG, "wakeUpApplication: " + attributeMap.get(EXTRA_CALL_UUID) + ", number : " + attributeMap.get(EXTRA_CALL_NUMBER) + ", displayName:" + attributeMap.get(EXTRA_CALLER_NAME));
+
+                    ComponentName name = reactContext.startService(headlessIntent);
+                    if (name != null) {
+                        HeadlessJsTaskService.acquireWakeLockNow(reactContext);
+                    }
                     break;
             }
         }

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -32,6 +32,7 @@ import android.graphics.drawable.Icon;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.WindowManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
@@ -420,11 +421,22 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         Context context = getAppContext();
         String packageName = context.getApplicationContext().getPackageName();
         Intent focusIntent = context.getPackageManager().getLaunchIntentForPackage(packageName).cloneFilter();
-
-        focusIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-
         Activity activity = getCurrentActivity();
-        activity.startActivity(focusIntent);
+        boolean isOpened = activity != null;
+        Log.d(TAG, "backToForeground, app isOpened ?" + (isOpened ? "true" : "false"));
+
+        if (isOpened) {
+            focusIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            activity.startActivity(focusIntent);
+        } else {
+
+            focusIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK +
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED +
+                    WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD +
+                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
+
+            getReactApplicationContext().startActivity(focusIntent);
+        }
     }
 
     private void registerPhoneAccount(Context appContext) {

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -37,17 +37,17 @@ import org.json.JSONObject;
 
 import java.util.HashMap;
 
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_ANSWER_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_AUDIO_SESSION;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_DTMF_TONE;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_END_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_HOLD_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_MUTE_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_UNHOLD_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_UNMUTE_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALLER_NAME;
-import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALL_NUMBER;
-import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALL_UUID;
+import static io.wazo.callkeep.Constants.ACTION_ANSWER_CALL;
+import static io.wazo.callkeep.Constants.ACTION_AUDIO_SESSION;
+import static io.wazo.callkeep.Constants.ACTION_DTMF_TONE;
+import static io.wazo.callkeep.Constants.ACTION_END_CALL;
+import static io.wazo.callkeep.Constants.ACTION_HOLD_CALL;
+import static io.wazo.callkeep.Constants.ACTION_MUTE_CALL;
+import static io.wazo.callkeep.Constants.ACTION_UNHOLD_CALL;
+import static io.wazo.callkeep.Constants.ACTION_UNMUTE_CALL;
+import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
+import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
+import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
 
 @TargetApi(Build.VERSION_CODES.M)
 public class VoiceConnection extends Connection {

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -40,6 +40,8 @@ import android.util.Log;
 import android.app.ActivityManager;
 import android.app.ActivityManager.RunningTaskInfo;
 
+import com.facebook.react.HeadlessJsTaskService;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -190,11 +192,19 @@ public class VoiceConnectionService extends ConnectionService {
     }
 
     private void wakeUpApplication(String uuid, String number, String displayName) {
-        HashMap<String, String> extrasMap = new HashMap();
-        extrasMap.put(EXTRA_CALL_UUID, uuid);
-        extrasMap.put(EXTRA_CALLER_NAME, displayName);
-        extrasMap.put(EXTRA_CALL_NUMBER, number);
-        sendCallRequestToActivity(ACTION_WAKE_APP, extrasMap);
+        Intent headlessIntent = new Intent(
+            this.getApplicationContext(),
+            RNCallKeepBackgroundMessagingService.class
+        );
+        headlessIntent.putExtra("callUUID", uuid);
+        headlessIntent.putExtra("name", displayName);
+        headlessIntent.putExtra("handle", number);
+        Log.d(TAG, "wakeUpApplication: " + uuid + ", number : " + number + ", displayName:" + displayName);
+
+        ComponentName name = this.getApplicationContext().startService(headlessIntent);
+        if (name != null) {
+          HeadlessJsTaskService.acquireWakeLockNow(this.getApplicationContext());
+        }
     }
 
     private void wakeUpAfterReachabilityTimeout(ConnectionRequest request) {

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -40,10 +40,6 @@ import android.util.Log;
 import android.app.ActivityManager;
 import android.app.ActivityManager.RunningTaskInfo;
 
-import com.facebook.react.HeadlessJsTaskService;
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.common.LifecycleState;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -53,20 +49,13 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_ANSWER_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_AUDIO_SESSION;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_DTMF_TONE;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_END_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_HOLD_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_MUTE_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_ONGOING_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_UNHOLD_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_UNMUTE_CALL;
-import static io.wazo.callkeep.RNCallKeepModule.ACTION_CHECK_REACHABILITY;
-import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALLER_NAME;
-import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALL_NUMBER;
-import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALL_UUID;
-import static io.wazo.callkeep.RNCallKeepModule.handle;
+import static io.wazo.callkeep.Constants.ACTION_AUDIO_SESSION;
+import static io.wazo.callkeep.Constants.ACTION_ONGOING_CALL;
+import static io.wazo.callkeep.Constants.ACTION_CHECK_REACHABILITY;
+import static io.wazo.callkeep.Constants.ACTION_WAKE_APP;
+import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
+import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
+import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
 
 // @see https://github.com/kbagchiGWC/voice-quickstart-android/blob/9a2aff7fbe0d0a5ae9457b48e9ad408740dfb968/exampleConnectionService/src/main/java/com/twilio/voice/examples/connectionservice/VoiceConnectionService.java
 @TargetApi(Build.VERSION_CODES.M)
@@ -76,6 +65,7 @@ public class VoiceConnectionService extends ConnectionService {
     private static Boolean isReachable;
     private static String notReachableCallUuid;
     private static ConnectionRequest currentConnectionRequest;
+    private static PhoneAccountHandle phoneAccountHandle;
     private static String TAG = "RNCK:VoiceConnectionService";
     public static Map<String, VoiceConnection> currentConnections = new HashMap<>();
     public static Boolean hasOutgoingCall = false;
@@ -96,6 +86,10 @@ public class VoiceConnectionService extends ConnectionService {
         isAvailable = false;
         currentConnectionRequest = null;
         currentConnectionService = this;
+    }
+
+    public static void setPhoneAccountHandle(PhoneAccountHandle phoneAccountHandle) {
+        VoiceConnectionService.phoneAccountHandle = phoneAccountHandle;
     }
 
     public static void setAvailable(Boolean value) {
@@ -196,19 +190,11 @@ public class VoiceConnectionService extends ConnectionService {
     }
 
     private void wakeUpApplication(String uuid, String number, String displayName) {
-        Intent headlessIntent = new Intent(
-            this.getApplicationContext(),
-            RNCallKeepBackgroundMessagingService.class
-        );
-        headlessIntent.putExtra("callUUID", uuid);
-        headlessIntent.putExtra("name", displayName);
-        headlessIntent.putExtra("handle", number);
-        Log.d(TAG, "wakeUpApplication: " + uuid + ", number : " + number + ", displayName:" + displayName);
-
-        ComponentName name = this.getApplicationContext().startService(headlessIntent);
-        if (name != null) {
-          HeadlessJsTaskService.acquireWakeLockNow(this.getApplicationContext());
-        }
+        HashMap<String, String> extrasMap = new HashMap();
+        extrasMap.put(EXTRA_CALL_UUID, uuid);
+        extrasMap.put(EXTRA_CALLER_NAME, displayName);
+        extrasMap.put(EXTRA_CALL_NUMBER, number);
+        sendCallRequestToActivity(ACTION_WAKE_APP, extrasMap);
     }
 
     private void wakeUpAfterReachabilityTimeout(ConnectionRequest request) {
@@ -271,9 +257,7 @@ public class VoiceConnectionService extends ConnectionService {
         VoiceConnection voiceConnection1 = (VoiceConnection) connection1;
         VoiceConnection voiceConnection2 = (VoiceConnection) connection2;
 
-        PhoneAccountHandle phoneAccountHandle = RNCallKeepModule.handle;
-
-        VoiceConference voiceConference = new VoiceConference(handle);
+        VoiceConference voiceConference = new VoiceConference(phoneAccountHandle);
         voiceConference.addConnection(voiceConnection1);
         voiceConference.addConnection(voiceConnection2);
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,10 @@ export default class RNCallKeep {
   static hasDefaultPhoneAccount(): boolean {
 
   }
+  
+  static answerIncomingCall(uuid: string) {
+
+  }
 
   static displayIncomingCall(
     uuid: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,7 +114,9 @@ export default class RNCallKeep {
   static setReachable() {
 
   }
+  static isCallActive(uuid: string): Promise<boolean> {
 
+  }
   /**
      * @description supportConnectionService method is available only on Android.
   */

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,6 +83,7 @@ export default class RNCallKeep {
     uuid: string,
     displayName: string,
     handle: string,
+    options?: object,
   ) {
 
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ export default class RNCallKeep {
     localizedCallerName?: string,
     handleType?: HandleType,
     hasVideo?: boolean,
+    options?: object,
   ) {
 
   }

--- a/index.js
+++ b/index.js
@@ -56,13 +56,25 @@ class RNCallKeep {
     return;
   };
 
-  displayIncomingCall = (uuid, handle, localizedCallerName = '', handleType = 'number', hasVideo = false) => {
+  displayIncomingCall = (uuid, handle, localizedCallerName = '', handleType = 'number', hasVideo = false, options = null) => {
     if (!isIOS) {
       RNCallKeepModule.displayIncomingCall(uuid, handle, localizedCallerName);
       return;
     }
 
-    RNCallKeepModule.displayIncomingCall(uuid, handle, handleType, hasVideo, localizedCallerName);
+    let supportsHolding = true,
+      supportsDTMF = true,
+      supportsGrouping = true,
+      supportsUngrouping = true;
+
+    if (options) {
+      if (typeof options.supportsHolding === 'boolean') supportsHolding = options.supportsHolding;
+      if (typeof options.supportsDTMF === 'boolean') supportsDTMF = options.supportsDTMF;
+      if (typeof options.supportsGrouping === 'boolean') supportsGrouping = options.supportsGrouping;
+      if (typeof options.supportsUngrouping === 'boolean') supportsUngrouping = options.supportsUngrouping;
+    }
+
+    RNCallKeepModule.displayIncomingCall(uuid, handle, handleType, hasVideo, localizedCallerName, supportsHolding, supportsDTMF, supportsGrouping, supportsUngrouping);
   };
 
   answerIncomingCall = (uuid) => {

--- a/index.js
+++ b/index.js
@@ -62,17 +62,11 @@ class RNCallKeep {
       return;
     }
 
-    let supportsHolding = true,
-      supportsDTMF = true,
-      supportsGrouping = true,
-      supportsUngrouping = true;
-
-    if (options) {
-      if (typeof options.supportsHolding === 'boolean') supportsHolding = options.supportsHolding;
-      if (typeof options.supportsDTMF === 'boolean') supportsDTMF = options.supportsDTMF;
-      if (typeof options.supportsGrouping === 'boolean') supportsGrouping = options.supportsGrouping;
-      if (typeof options.supportsUngrouping === 'boolean') supportsUngrouping = options.supportsUngrouping;
-    }
+    // should be boolean type value
+    let supportsHolding = !!(options?.ios?.supportsHolding ?? true);
+    let supportsDTMF = !!(options?.ios?.supportsDTMF ?? true);
+    let supportsGrouping = !!(options?.ios?.supportsGrouping ?? true);
+    let supportsUngrouping = !!(options?.ios?.supportsUngrouping ?? true);
 
     RNCallKeepModule.displayIncomingCall(uuid, handle, handleType, hasVideo, localizedCallerName, supportsHolding, supportsDTMF, supportsGrouping, supportsUngrouping);
   };
@@ -173,10 +167,13 @@ class RNCallKeep {
       return;
     }
 
-    if (!options) {
-      options = {};
+    let iosOptions = {};
+    if (options && options.ios) {
+      iosOptions = {
+        ...options.ios,
+      }
     }
-    RNCallKeepModule.updateDisplay(uuid, displayName, handle, options);
+    RNCallKeepModule.updateDisplay(uuid, displayName, handle, iosOptions);
   };
 
   setOnHold = (uuid, shouldHold) => RNCallKeepModule.setOnHold(uuid, shouldHold);

--- a/index.js
+++ b/index.js
@@ -108,6 +108,8 @@ class RNCallKeep {
     }
   };
 
+  isCallActive = async(uuid) => await RNCallKeepModule.isCallActive(uuid);
+
   endCall = (uuid) => RNCallKeepModule.endCall(uuid);
 
   endAllCalls = () => RNCallKeepModule.endAllCalls();

--- a/index.js
+++ b/index.js
@@ -167,7 +167,17 @@ class RNCallKeep {
     RNCallKeepModule.setCurrentCallActive(callUUID);
   };
 
-  updateDisplay = (uuid, displayName, handle) => RNCallKeepModule.updateDisplay(uuid, displayName, handle);
+  updateDisplay = (uuid, displayName, handle, options = null) => {
+    if (!isIOS) {
+      RNCallKeepModule.updateDisplay(uuid, displayName, handle);
+      return;
+    }
+
+    if (!options) {
+      options = {};
+    }
+    RNCallKeepModule.updateDisplay(uuid, displayName, handle, options);
+  };
 
   setOnHold = (uuid, shouldHold) => RNCallKeepModule.setOnHold(uuid, shouldHold);
 

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -32,6 +32,10 @@ continueUserActivity:(NSUserActivity *)userActivity
                    handleType:(NSString *)handleType
                      hasVideo:(BOOL)hasVideo
           localizedCallerName:(NSString * _Nullable)localizedCallerName
+              supportsHolding:(BOOL)supportsHolding
+                 supportsDTMF:(BOOL)supportsDTMF
+             supportsGrouping:(BOOL)supportsGrouping
+           supportsUngrouping:(BOOL)supportsUngrouping
                   fromPushKit:(BOOL)fromPushKit
                       payload:(NSDictionary * _Nullable)payload;
 

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -37,14 +37,6 @@ continueUserActivity:(NSUserActivity *)userActivity
              supportsGrouping:(BOOL)supportsGrouping
            supportsUngrouping:(BOOL)supportsUngrouping
                   fromPushKit:(BOOL)fromPushKit
-                      payload:(NSDictionary * _Nullable)payload;
-
-+ (void)reportNewIncomingCall:(NSString *)uuidString
-                       handle:(NSString *)handle
-                   handleType:(NSString *)handleType
-                     hasVideo:(BOOL)hasVideo
-          localizedCallerName:(NSString * _Nullable)localizedCallerName
-                  fromPushKit:(BOOL)fromPushKit
                       payload:(NSDictionary * _Nullable)payload
         withCompletionHandler:(void (^_Nullable)(void))completion;
 

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -46,4 +46,7 @@ continueUserActivity:(NSUserActivity *)userActivity
 
 + (void)endCallWithUUID:(NSString *)uuidString
                  reason:(int)reason;
+
++ (BOOL)isCallActive:(NSString *)uuidString;
+
 @end

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -35,6 +35,15 @@ continueUserActivity:(NSUserActivity *)userActivity
                   fromPushKit:(BOOL)fromPushKit
                       payload:(NSDictionary * _Nullable)payload;
 
++ (void)reportNewIncomingCall:(NSString *)uuidString
+                       handle:(NSString *)handle
+                   handleType:(NSString *)handleType
+                     hasVideo:(BOOL)hasVideo
+          localizedCallerName:(NSString * _Nullable)localizedCallerName
+                  fromPushKit:(BOOL)fromPushKit
+                      payload:(NSDictionary * _Nullable)payload
+        withCompletionHandler:(void (^_Nullable)(void))completion;
+
 + (void)endCallWithUUID:(NSString *)uuidString
                  reason:(int)reason;
 @end

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -398,17 +398,6 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
            supportsUngrouping:(BOOL)supportsUngrouping
                   fromPushKit:(BOOL)fromPushKit
                       payload:(NSDictionary * _Nullable)payload
-{
-    [RNCallKeep reportNewIncomingCall:uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit:fromPushKit payload:payload withCompletionHandler:nil];
-}
-
-+ (void)reportNewIncomingCall:(NSString *)uuidString
-                       handle:(NSString *)handle
-                   handleType:(NSString *)handleType
-                     hasVideo:(BOOL)hasVideo
-          localizedCallerName:(NSString * _Nullable)localizedCallerName
-                  fromPushKit:(BOOL)fromPushKit
-                      payload:(NSDictionary * _Nullable)payload
         withCompletionHandler:(void (^_Nullable)(void))completion
 {
 #ifdef DEBUG
@@ -451,28 +440,6 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
             completion();
         }
     }];
-}
-
-// --- overloading functions for backward compatibility and simple api
-+ (void)reportNewIncomingCall:(NSString *)uuidString
-                       handle:(NSString *)handle
-                   handleType:(NSString *)handleType
-                     hasVideo:(BOOL)hasVideo
-          localizedCallerName:(NSString * _Nullable)localizedCallerName
-                  fromPushKit:(BOOL)fromPushKit
-{
-    [RNCallKeep reportNewIncomingCall: uuidString
-                               handle: handle
-                           handleType: handleType
-                             hasVideo: hasVideo
-                  localizedCallerName: localizedCallerName
-                      supportsHolding: YES
-                         supportsDTMF: YES
-                     supportsGrouping: YES
-                   supportsUngrouping: YES
-                          fromPushKit: fromPushKit
-                              payload: nil
-                withCompletionHandler: nil];
 }
 
 - (BOOL)lessThanIos10_2

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -462,7 +462,7 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
         int _handleType = [RNCallKeep getHandleType:settings[@"handleType"]];
         providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:_handleType], nil];
     }else{
-        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypeGeneric], nil];
+        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypePhoneNumber], nil];
     }
     if (settings[@"supportsVideo"]) {
         providerConfiguration.supportsVideo = [settings[@"supportsVideo"] boolValue];

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -149,9 +149,24 @@ RCT_EXPORT_METHOD(displayIncomingCall:(NSString *)uuidString
                                handle:(NSString *)handle
                            handleType:(NSString *)handleType
                              hasVideo:(BOOL)hasVideo
-                  localizedCallerName:(NSString * _Nullable)localizedCallerName)
+                  localizedCallerName:(NSString * _Nullable)localizedCallerName
+                      supportsHolding:(BOOL)supportsHolding
+                         supportsDTMF:(BOOL)supportsDTMF
+                     supportsGrouping:(BOOL)supportsGrouping
+                   supportsUngrouping:(BOOL)supportsUngrouping)            
 {
-    [RNCallKeep reportNewIncomingCall: uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit: NO payload:nil withCompletionHandler:nil];
+    [RNCallKeep reportNewIncomingCall: uuidString
+                               handle: handle
+                           handleType: handleType
+                             hasVideo: hasVideo
+                  localizedCallerName: localizedCallerName
+                      supportsHolding: supportsHolding
+                         supportsDTMF: supportsDTMF
+                     supportsGrouping: supportsGrouping
+                   supportsUngrouping: supportsUngrouping
+                          fromPushKit: NO
+                              payload: nil
+                withCompletionHandler: nil];
 }
 
 RCT_EXPORT_METHOD(startCall:(NSString *)uuidString
@@ -360,6 +375,10 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
                    handleType:(NSString *)handleType
                      hasVideo:(BOOL)hasVideo
           localizedCallerName:(NSString * _Nullable)localizedCallerName
+              supportsHolding:(BOOL)supportsHolding
+                 supportsDTMF:(BOOL)supportsDTMF
+             supportsGrouping:(BOOL)supportsGrouping
+           supportsUngrouping:(BOOL)supportsUngrouping
                   fromPushKit:(BOOL)fromPushKit
                       payload:(NSDictionary * _Nullable)payload
 {
@@ -382,10 +401,10 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
     callUpdate.remoteHandle = [[CXHandle alloc] initWithType:_handleType value:handle];
-    callUpdate.supportsDTMF = YES;
-    callUpdate.supportsHolding = YES;
-    callUpdate.supportsGrouping = YES;
-    callUpdate.supportsUngrouping = YES;
+    callUpdate.supportsHolding = supportsHolding;
+    callUpdate.supportsDTMF = supportsDTMF;
+    callUpdate.supportsGrouping = supportsGrouping;
+    callUpdate.supportsUngrouping = supportsUngrouping;
     callUpdate.hasVideo = hasVideo;
     callUpdate.localizedCallerName = localizedCallerName;
 
@@ -398,6 +417,10 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
             @"handle": handle,
             @"localizedCallerName": localizedCallerName ? localizedCallerName : @"",
             @"hasVideo": hasVideo ? @"1" : @"0",
+            @"supportsHolding": supportsHolding ? @"1" : @"0",
+            @"supportsDTMF": supportsDTMF ? @"1" : @"0",
+            @"supportsGrouping": supportsGrouping ? @"1" : @"0",
+            @"supportsUngrouping": supportsUngrouping ? @"1" : @"0",
             @"fromPushKit": fromPushKit ? @"1" : @"0",
             @"payload": payload ? payload : @"",
         }];
@@ -413,6 +436,7 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
     }];
 }
 
+// --- overloading functions for backward compatibility and simple api
 + (void)reportNewIncomingCall:(NSString *)uuidString
                        handle:(NSString *)handle
                    handleType:(NSString *)handleType
@@ -420,7 +444,18 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
           localizedCallerName:(NSString * _Nullable)localizedCallerName
                   fromPushKit:(BOOL)fromPushKit
 {
-    [RNCallKeep reportNewIncomingCall: uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit: fromPushKit payload:nil withCompletionHandler:nil];
+    [RNCallKeep reportNewIncomingCall: uuidString
+                               handle: handle
+                           handleType: handleType
+                             hasVideo: hasVideo
+                  localizedCallerName: localizedCallerName
+                      supportsHolding: YES
+                         supportsDTMF: YES
+                     supportsGrouping: YES
+                   supportsUngrouping: YES
+                          fromPushKit: fromPushKit
+                              payload: nil
+                withCompletionHandler: nil];
 }
 
 - (BOOL)lessThanIos10_2

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -249,7 +249,7 @@ RCT_EXPORT_METHOD(reportEndCallWithUUID:(NSString *)uuidString :(int)reason)
     [RNCallKeep endCallWithUUID: uuidString reason:reason];
 }
 
-RCT_EXPORT_METHOD(updateDisplay:(NSString *)uuidString :(NSString *)displayName :(NSString *)uri)
+RCT_EXPORT_METHOD(updateDisplay:(NSString *)uuidString :(NSString *)displayName :(NSString *)uri :(NSDictionary *)options)
 {
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][updateDisplay] uuidString = %@ displayName = %@ uri = %@", uuidString, displayName, uri);
@@ -259,6 +259,23 @@ RCT_EXPORT_METHOD(updateDisplay:(NSString *)uuidString :(NSString *)displayName 
     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
     callUpdate.localizedCallerName = displayName;
     callUpdate.remoteHandle = callHandle;
+
+    if ([options valueForKey:@"hasVideo"] != nil) {
+        callUpdate.hasVideo = [RCTConvert BOOL:options[@"hasVideo"]];
+    }
+    if ([options valueForKey:@"supportsHolding"] != nil) {
+        callUpdate.supportsHolding = [RCTConvert BOOL:options[@"supportsHolding"]];
+    }
+    if ([options valueForKey:@"supportsDTMF"] != nil) {
+        callUpdate.supportsDTMF = [RCTConvert BOOL:options[@"supportsDTMF"]];
+    }
+    if ([options valueForKey:@"supportsGrouping"] != nil) {
+        callUpdate.supportsGrouping = [RCTConvert BOOL:options[@"supportsGrouping"]];
+    }
+    if ([options valueForKey:@"supportsUngrouping"] != nil) {
+        callUpdate.supportsUngrouping = [RCTConvert BOOL:options[@"supportsUngrouping"]];
+    }
+
     [self.callKeepProvider reportCallWithUUID:uuid updated:callUpdate];
 }
 

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -273,6 +273,14 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
     [self requestTransaction:transaction];
 }
 
+RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKeep][isCallActive] uuid = %@", uuidString);
+#endif
+    [RNCallKeep isCallActive: uuidString];
+}
+
 - (void)requestTransaction:(CXTransaction *)transaction
 {
 #ifdef DEBUG
@@ -302,6 +310,20 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
             }
         }
     }];
+}
+
++ (BOOL)isCallActive:(NSString *)uuidString
+{
+    CXCallObserver *callObserver = [[CXCallObserver alloc] init];
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+
+    for(CXCall *call in callObserver.calls){
+        NSLog(@"[RNCallKeep] isCallActive %@ %d ?", call.UUID, [call.UUID isEqual:uuid]);
+        if([call.UUID isEqual:[[NSUUID alloc] initWithUUIDString:uuidString]] && !call.hasConnected){
+            return true;
+        }
+    }
+    return false;
 }
 
 + (void)endCallWithUUID:(NSString *)uuidString

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -151,7 +151,7 @@ RCT_EXPORT_METHOD(displayIncomingCall:(NSString *)uuidString
                              hasVideo:(BOOL)hasVideo
                   localizedCallerName:(NSString * _Nullable)localizedCallerName)
 {
-    [RNCallKeep reportNewIncomingCall: uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit: NO payload:nil];
+    [RNCallKeep reportNewIncomingCall: uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit: NO payload:nil withCompletionHandler:nil];
 }
 
 RCT_EXPORT_METHOD(startCall:(NSString *)uuidString
@@ -341,6 +341,18 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
                   fromPushKit:(BOOL)fromPushKit
                       payload:(NSDictionary * _Nullable)payload
 {
+    [RNCallKeep reportNewIncomingCall:uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit:fromPushKit payload:payload withCompletionHandler:nil];
+}
+
++ (void)reportNewIncomingCall:(NSString *)uuidString
+                       handle:(NSString *)handle
+                   handleType:(NSString *)handleType
+                     hasVideo:(BOOL)hasVideo
+          localizedCallerName:(NSString * _Nullable)localizedCallerName
+                  fromPushKit:(BOOL)fromPushKit
+                      payload:(NSDictionary * _Nullable)payload
+        withCompletionHandler:(void (^_Nullable)(void))completion
+{
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][reportNewIncomingCall] uuidString = %@", uuidString);
 #endif
@@ -373,6 +385,9 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
                 [callKeep configureAudioSession];
             }
         }
+        if (completion != nil) {
+            completion();
+        }
     }];
 }
 
@@ -383,7 +398,7 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
           localizedCallerName:(NSString * _Nullable)localizedCallerName
                   fromPushKit:(BOOL)fromPushKit
 {
-    [RNCallKeep reportNewIncomingCall: uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit: fromPushKit payload:nil];
+    [RNCallKeep reportNewIncomingCall: uuidString handle:handle handleType:handleType hasVideo:hasVideo localizedCallerName:localizedCallerName fromPushKit: fromPushKit payload:nil withCompletionHandler:nil];
 }
 
 - (BOOL)lessThanIos10_2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-callkeep",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "iOS 10 CallKit and Android ConnectionService Framework For React Native",
   "main": "index.js",
   "scripts": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-callkeep",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "iOS 10 CallKit and Android ConnectionService Framework For React Native",
   "main": "index.js",
   "scripts": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-callkeep",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "description": "iOS 10 CallKit and Android ConnectionService Framework For React Native",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Support addition options can pass from js method

### `updateDisplay`

#### original:
`updateDisplay = (uuid, displayName, handle)`

#### new:
`updateDisplay = (uuid, displayName, handle, options = null)`
where the optional options could be:
```js
{
  hasVideo: true,
  supportsHolding: true,
  supportsDTMF: true,
  supportsGrouping: true,
  supportsUngrouping: true,
} 
```

### `displayIncomingCall`

#### original:
`displayIncomingCall = (uuid, handle, localizedCallerName, handleType = 'number', hasVideo = false)`

#### new:
`displayIncomingCall = (uuid, handle, localizedCallerName, handleType = 'number', hasVideo = false, options = null)`
where the optional options could be:
```js
{
  supportsHolding: true,
  supportsDTMF: true,
  supportsGrouping: true,
  supportsUngrouping: true,
} 
```

### Note for API compatibility:

1.
Originally, `displayIncomingCall`already has `hasVideo` argument but `updateDisplay` are not. For api compatibility, I did NOT move `displayIncomingCall.hasVideo` inside  `displayIncomingCall.options`

2.
In the earlier time, we've exposed native `reportNewIncomingCall` and introduced an overloading function for the new `payload`argument for api compatibility:

#### Earlier Original (as simple api):
`[RNCallKeep reportNewIncomingCall:uuid handle:handle handleType:@"generic" hasVideo:false localizedCallerName:callerName fromPushKit: YES];`

and 

#### Earlier New (as full api):
`[RNCallKeep reportNewIncomingCall:uuid handle:handle handleType:@"generic" hasVideo:false localizedCallerName:callerName fromPushKit: YES payload:extra];`

We can't have too much overloading functions, so I keep the original one, and extend the new overloading function, so now is:

#### This PR Original (as simple api):
`[RNCallKeep reportNewIncomingCall:uuid handle:handle handleType:@"generic" hasVideo:false localizedCallerName:callerName fromPushKit: YES];`

and 

#### This PR New (as full api):
`[RNCallKeep reportNewIncomingCall:uuid handle:handle handleType:@"generic" hasVideo:false localizedCallerName:callerName supportsHolding: YES supportsDTMF: YES supportsGrouping: YES supportsUngrouping: YES fromPushKit: YES payload: payload];`

### TL;DR

For user using native `RNCallKeep reportNewIncomingCall` with `payload` argument should change to `[RNCallKeep reportNewIncomingCall:uuid handle:handle handleType:@"generic" hasVideo:false localizedCallerName:callerName supportsHolding: YES supportsDTMF: YES supportsGrouping: YES supportsUngrouping: YES fromPushKit: YES payload: payload];`

