### PR TITLE
Handle issue with JS not initialized on start to fix #107

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,26 @@ RNCallKeep.addEventListener('didPerformDTMFAction', ({ digits, callUUID }) => {
 - `callUUID` (string)
   - The UUID of the call.
 
+### - didLoadWithEvents
+
+iOS only.
+
+Called as soon as JS context initializes if there were some actions performed by user before JS context has been created.
+
+Since iOS 13, you must display incoming call on receiving PushKit push notification. But if app was killed, it takes some time to create JS context. If user answers the call (or ends it) before JS context has been initialized, user actions will be passed as events array of this event. Similar situation can happen if user would like to start a call from Recents or similar iOS app, assuming that your app was in killed state.
+
+```js
+RNCallKeep.addEventListener('didLoadWithEvents', (events) => {
+  // see example usage in https://github.com/react-native-webrtc/react-native-callkeep/pull/169
+});
+```
+
+- `events` Array
+  - `name`: string
+    Native event name like: `RNCallKeepPerformAnswerCallAction`
+  - `data`: object
+    Object with data passed together with specific event so it can be handled in the same way like original event, for example `({ callUUID })` for `answerCall` event if `name` is `RNCallKeepPerformAnswerCallAction`
+
 ### - checkReachability
 
 On Android when the application is in background, after a certain delay the OS will close every connection with informing about it.

--- a/actions.js
+++ b/actions.js
@@ -14,6 +14,7 @@ const RNCallKeepDidToggleHoldAction = 'RNCallKeepDidToggleHoldAction';
 const RNCallKeepDidPerformDTMFAction = 'RNCallKeepDidPerformDTMFAction';
 const RNCallKeepProviderReset = 'RNCallKeepProviderReset';
 const RNCallKeepCheckReachability = 'RNCallKeepCheckReachability';
+const RNCallKeepDidLoadWithEvents = 'RNCallKeepDidLoadWithEvents';
 const isIOS = Platform.OS === 'ios';
 
 const didReceiveStartCallAction = handler => {
@@ -55,6 +56,9 @@ const didResetProvider = handler =>
 const checkReachability = handler =>
   eventEmitter.addListener(RNCallKeepCheckReachability, handler);
 
+const didLoadWithEvents = handler =>
+  eventEmitter.addListener(RNCallKeepDidLoadWithEvents, handler);
+
 export const listeners = {
   didReceiveStartCallAction,
   answerCall,
@@ -67,4 +71,5 @@ export const listeners = {
   didPerformDTMFAction,
   didResetProvider,
   checkReachability,
+  didLoadWithEvents
 };

--- a/actions.js
+++ b/actions.js
@@ -59,6 +59,8 @@ const checkReachability = handler =>
 const didLoadWithEvents = handler =>
   eventEmitter.addListener(RNCallKeepDidLoadWithEvents, handler);
 
+export const emit = (eventName, payload) => eventEmitter.emit(eventName, payload);
+
 export const listeners = {
   didReceiveStartCallAction,
   answerCall,
@@ -71,5 +73,5 @@ export const listeners = {
   didPerformDTMFAction,
   didResetProvider,
   checkReachability,
-  didLoadWithEvents
+  didLoadWithEvents,
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,8 @@ export type Events =
   'didPerformDTMFAction' |
   'didResetProvider' |
   'checkReachability' |
-  'didPerformSetMutedCallAction';
+  'didPerformSetMutedCallAction' |
+  'didLoadWithEvents';
 
 type HandleType = 'generic' | 'number' | 'email';
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class RNCallKeep {
 
     this.addEventListener('didLoadWithEvents', (events) => {
       events.forEach(event => {
-        emit(evemt.name, event.data);
+        emit(event.name, event.data);
       });
     });
   }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { NativeModules, Platform, Alert } from 'react-native';
 
-import { listeners } from './actions'
+import { listeners, emit } from './actions'
 
 const RNCallKeepModule = NativeModules.RNCallKeep;
 const isIOS = Platform.OS === 'ios';
@@ -22,6 +22,12 @@ class RNCallKeep {
 
   constructor() {
     this._callkeepEventHandlers = new Map();
+
+    this.addEventListener('didLoadWithEvents', (events) => {
+      events.forEach(event => {
+        emit(evemt.name, event.data);
+      });
+    });
   }
 
   addEventListener = (type, handler) => {

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -41,7 +41,6 @@ static NSString *const RNCallKeepDidLoadWithEvents = @"RNCallKeepDidLoadWithEven
     BOOL _isStartCallActionEventListenerAdded;
     bool _hasListeners;
     NSMutableArray *_delayedEvents;
-
 }
 
 static CXProvider* sharedProvider;

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -619,7 +619,7 @@ continueUserActivity:(NSUserActivity *)userActivity
         };
 
         RNCallKeep *callKeep = [RNCallKeep allocWithZone: nil];
-        [callKeep handleStartCallNotification: userInfo];
+        [callKeep sendEventWithNameWrapper:RNCallKeepDidReceiveStartCallAction body:userInfo];
         return YES;
     }
     return NO;

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -629,24 +629,6 @@ continueUserActivity:(NSUserActivity *)userActivity
     return YES;
 }
 
-- (void)handleStartCallNotification:(NSDictionary *)userInfo
-{
-#ifdef DEBUG
-    NSLog(@"[RNCallKeep][handleStartCallNotification] userInfo = %@", userInfo);
-#endif
-    int delayInSeconds;
-    if (!_isStartCallActionEventListenerAdded) {
-        // Workaround for when app is just launched and JS side hasn't registered to the event properly
-        delayInSeconds = OUTGOING_CALL_WAKEUP_DELAY;
-    } else {
-        delayInSeconds = 0;
-    }
-    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
-    dispatch_after(popTime, dispatch_get_main_queue(), ^{
-        [self sendEventWithNameWrapper:RNCallKeepDidReceiveStartCallAction body:userInfo];
-    });
-}
-
 #pragma mark - CXProviderDelegate
 
 - (void)providerDidReset:(CXProvider *)provider{


### PR DESCRIPTION
Based on #169 

----


Proof of concept to handle issue with JS not initialized on start to fix #107

Described in details here: https://github.com/react-native-webrtc/react-native-callkeep/issues/107#issuecomment-581845376

Example usage:
```
import { each, compact, last, get } from 'lodash';

RNCallKeep.addEventListener(
  'didLoadWithEvents',
  this.onDidLoadWithNativeEvents
);

onDidLoadWithNativeEvents(events) {
  const validEvents = compact(events);
  let callDataToAdd = null;
  let callDataToAnswer = null;
  let callDataToReject = null;
  let callDataToInitiateCall = null;
  each(compact(validEvents), event => {
    const { name, data } = event;
    if (name === 'RNCallKeepDidDisplayIncomingCall') {
      callDataToAdd = data;
      callDataToAnswer = null;
      callDataToReject = null;
    }
    if (name === 'RNCallKeepPerformAnswerCallAction') {
      callDataToReject = null;
      callDataToAnswer = data;
    }
    if (name === 'RNCallKeepPerformEndCallAction') {
      callDataToAnswer = null;
      callDataToReject = data;
    }
  });

  const lastEventName = get(last(validEvents), 'name');
  if (lastEventName === 'RNCallKeepDidReceiveStartCallAction') {
    callDataToInitiateCall = get(last(validEvents), 'data');
    callDataToAnswer = null;
    if (!callDataToReject) {
      callDataToAdd = null;
    }
  }

  if (callDataToAdd) {
    this.onDisplayIncomingCall(callDataToAdd);
    if (callDataToReject) {
      this.onEndCall(callDataToReject);
    }
    if (callDataToAnswer) {
      this.onAnswerCall(callDataToAnswer);
    }
  }
  if (callDataToInitiateCall) {
    this.onStartCall(callDataToAnswer);
  }
}
```