### PR TITLE
Fix didReceiveOnStartcallAction not working

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -462,7 +462,7 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
         int _handleType = [RNCallKeep getHandleType:settings[@"handleType"]];
         providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:_handleType], nil];
     }else{
-        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypeGeneric], nil];
+        providerConfiguration.supportedHandleTypes = [NSSet setWithObjects:[NSNumber numberWithInteger:CXHandleTypePhoneNumber], nil];
     }
     if (settings[@"supportsVideo"]) {
         providerConfiguration.supportsVideo = [settings[@"supportsVideo"] boolValue];


### PR DESCRIPTION
Fixes #206 

The default `supportedHandleTypes` was changed from `CXHandleTypePhoneNumber` to `CXHandleTypeGeneric` in #171, breaking the start call from recents action.
