### PR TITLE
Allow user to handle phone account manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,29 @@ const options = {
 RNCallKeep.hasDefaultPhoneAccount(options);
 ```
 
+### checkPhoneAccountEnabled
+
+Checks if the user has set a default [phone account](https://developer.android.com/reference/android/telecom/PhoneAccount) and it's enabled.
+
+It's useful for custom permission prompts. It should be used in pair with `registerPhoneAccount`
+
+_This feature is available only on Android._
+
+```js
+RNCallKeep.checkPhoneAccountEnabled();
+```
+
+### registerPhoneAccount
+
+Registers phone account manualy. It should be called before `checkPhoneAccountEnabled`.
+
+It's useful for custom permission prompts.
+
+_This feature is available only on Android._
+
+```js
+RNCallKeep.registerPhoneAccount();
+```
 
 ## Events
 

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -475,7 +475,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
             this.headlessExtras = null;
 
-            return
+            return;
         }
 
         promise.resolve(null);

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -269,7 +269,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void checkPhoneAccountEnabled(Promise promise) {
-        return promise.resolve(telecomManager != null && telecomManager.getPhoneAccount(handle).isEnabled()))
+        promise.resolve(hasPhoneAccount());
     }
 
     @ReactMethod

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -452,9 +452,10 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         boolean isOpened = activity != null;
 
         if (!isOpened) {
-            focusIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK +
-                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED +
-                    WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD +
+            focusIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK |
+                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON |
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+                    WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD |
                     WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
 
             final WritableMap response = new WritableNativeMap();

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -438,7 +438,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     private void registerPhoneAccount(Context appContext) {
-        if (!isConnectionServiceAvailable() || checkPhoneAccountEnabled()) {
+        if (!isConnectionServiceAvailable() || hasPhoneAccount()) {
             return;
         }
 

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -129,6 +129,11 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void registerPhoneAccount() {
+        this.registerPhoneAccount(this.getAppContext());
+    }
+
+    @ReactMethod
     public void displayIncomingCall(String uuid, String number, String callerName) {
         if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
             return;
@@ -260,6 +265,11 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         boolean hasDefaultAccount = telecomManager.getDefaultOutgoingPhoneAccount("tel") != null;
 
         promise.resolve(!hasSim || hasDefaultAccount);
+    }
+
+    @ReactMethod
+    public void checkPhoneAccountEnabled(Promise promise) {
+        return promise.resolve(telecomManager != null && telecomManager.getPhoneAccount(handle).isEnabled()))
     }
 
     @ReactMethod
@@ -428,7 +438,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     private void registerPhoneAccount(Context appContext) {
-        if (!isConnectionServiceAvailable()) {
+        if (!isConnectionServiceAvailable() || checkPhoneAccountEnabled()) {
             return;
         }
 

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -469,7 +469,15 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getExtrasFromHeadlessMode(Promise promise) {
-        promise.resolve(this.headlessExtras);
+        if (this.headlessExtras != null) {
+            promise.resolve(this.headlessExtras);
+
+            this.headlessExtras = null;
+
+            return
+        }
+
+        promise.resolve(null);
     }
 
     private void registerPhoneAccount(Context appContext) {

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -49,6 +49,7 @@ import android.util.Log;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,9 @@ export type AnswerCallPayload = { callUUID: string };
 export type EndCallPayload = AnswerCallPayload;
 export type DidDisplayIncomingCallPayload = string | undefined;
 export type DidPerformSetMutedCallActionPayload = boolean;
+export type HeadlessExtras = {
+  callUUID: string
+}
 
 export default class RNCallKeep {
   static addEventListener(type: Events, handler: (args: any) => void) {
@@ -180,5 +183,5 @@ export default class RNCallKeep {
   }
 
   static openAppFromHeadlessMode(callUUID: string): void
-  static getExtrasFromHeadlessMode(): Promise<string | null>
+  static getExtrasFromHeadlessMode(): Promise<HeadlessExtras>
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,9 @@ export default class RNCallKeep {
 
   }
 
+  static checkPhoneAccountEnabled(): Promise<boolean>
+  static registerPhoneAccount(): void
+
   static displayIncomingCall(
     uuid: string,
     handle: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -179,6 +179,6 @@ export default class RNCallKeep {
 
   }
 
-  openAppFromHeadlessMode(callUUID: string): void
-  getExtrasFromHeadlessMode(): Promise<string | null>
+  static openAppFromHeadlessMode(callUUID: string): void
+  static getExtrasFromHeadlessMode(): Promise<string | null>
 }

--- a/index.js
+++ b/index.js
@@ -48,6 +48,16 @@ class RNCallKeep {
     return this._setupIOS(options.ios);
   };
 
+  checkPhoneAccountEnabled = async () => {
+    if (isIOS) {
+      return;
+    }
+
+    return RNCallKeep.checkPhoneAccountEnabled();
+  }
+
+  registerPhoneAccount = () => RNCallKeep.registerPhoneAccount()
+
   hasDefaultPhoneAccount = async (options) => {
     if (!isIOS) {
       return this._hasDefaultPhoneAccount(options);

--- a/index.js
+++ b/index.js
@@ -194,6 +194,12 @@ class RNCallKeep {
   _setupAndroid = async (options) => {
     RNCallKeepModule.setup(options);
 
+    const hasDefaultAccount = await RNCallKeepModule.checkDefaultPhoneAccount()
+
+    if (hasDefaultAccount) {
+      return true
+    }
+
     const showAccountAlert = await RNCallKeepModule.checkPhoneAccountPermission(options.additionalPermissions || []);
     const shouldOpenAccounts = await this._alert(options, showAccountAlert);
 

--- a/index.js
+++ b/index.js
@@ -53,10 +53,10 @@ class RNCallKeep {
       return;
     }
 
-    return RNCallKeep.checkPhoneAccountEnabled();
+    return RNCallKeepModule.checkPhoneAccountEnabled();
   }
 
-  registerPhoneAccount = () => RNCallKeep.registerPhoneAccount()
+  registerPhoneAccount = () => RNCallKeepModule.registerPhoneAccount()
 
   hasDefaultPhoneAccount = async (options) => {
     if (!isIOS) {

--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ class RNCallKeep {
   _setupAndroid = async (options) => {
     RNCallKeepModule.setup(options);
 
-    const hasDefaultAccount = await RNCallKeepModule.checkDefaultPhoneAccount()
+    const hasDefaultAccount = await RNCallKeepModule.checkPhoneAccountEnabled()
 
     if (hasDefaultAccount) {
       return true

--- a/index.js
+++ b/index.js
@@ -56,7 +56,13 @@ class RNCallKeep {
     return RNCallKeepModule.checkPhoneAccountEnabled();
   }
 
-  registerPhoneAccount = () => RNCallKeepModule.registerPhoneAccount()
+  registerPhoneAccount = () => {
+    if (isIOS) {
+      return;
+    }
+
+    RNCallKeepModule.registerPhoneAccount();
+  }
 
   hasDefaultPhoneAccount = async (options) => {
     if (!isIOS) {


### PR DESCRIPTION
This small PR allows user to handle phone account flow manually.
Currently, the library is too obtrusive and it can be an issue for a well-designed app which doesn't want to display ugly Android alert.

What I'm proposing is another way for the developer to handle Android's phone account. Changes are backwards compatible so it can be released as a minor version.

How `react-native-callkeep` works now:
1. User can handle `microphone`, `camera` and `phone state` permissions manually. If user accepts it before `RNCallKeep.setup`, library won't display any prompts
2. After initial `setup` JS part of the lib will prompt the user to enable phone account and we can only inject alert's title and message
3. As a developer, I cannot change this behaviour

How library will work with this PR merged to master:
1. Same as in the master branch, we can request every permission beforehand
2. Developer can check if account permission is already enabled (eg. for visual representation) with new method `checkPhoneAccountEnabled`
3. Developer can register phone account manually (before `setup`) with new method `registerPhoneAccount` - with such option we can prompt the user and navigate to account settings manually, we can use our UI eg.:

<img src="https://user-images.githubusercontent.com/9088288/85038960-80edf080-b187-11ea-8b8b-0173df6b4a90.png" alt="example" width="300" />

4. At this point, we can `setup` library and enjoy CallKeep without any additional alerts or prompts ;)