### PR TITLE
setCurrentCallActive should expect a callUUID parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -172,7 +172,7 @@ export default class RNCallKeep {
 
   }
 
-  static setCurrentCallActive() {
+  static setCurrentCallActive(callUUID: string) {
 
   }
 


### PR DESCRIPTION
See [this](https://github.com/react-native-webrtc/react-native-callkeep/issues/90) issue.