### PR TITLE
[Android] Split setup into registerPhoneAccount and registerAndroidEvents

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 example/
 node_modules/
+.idea/
+.github/
+docs/

--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ Registers Android phone account manually, useful for custom permission prompts w
 This method is called by `setup`, if you already use setup you don't need it.
 
 _This feature is available only on Android._
+_On iOS you still have to call `setup()`._
 
 ```js
 RNCallKeep.registerPhoneAccount();
@@ -566,6 +567,7 @@ Registers Android UI events, useful when you don't want to call `setup()`.
 This method is called by `setup`, if you already use setup you don't need it.
 
 _This feature is available only on Android._
+_On iOS you still have to call `setup()`._
 
 ```js
 RNCallKeep.registerAndroidEvents();

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ RNCallKeep.setup(options).then(accepted => {});
     - `additionalPermissions`: [PermissionsAndroid] (optional)
       Any additional permissions you'd like your app to have at first launch. Can be used to simplify permission flows and avoid
       multiple popups to the user at different times.
+      
+`setup` calls internally `registerPhoneAccount` and `registerEvents`.
 
 ## Constants
 
@@ -545,6 +547,28 @@ Allows to remove the listener on an event.
 
 ```js
 RNCallKeep.removeEventListener('checkReachability');
+```
+
+### registerPhoneAccount
+
+Registers Android phone account manually, useful for custom permission prompts when you don't want to call `setup()`.
+This method is called by `setup`, if you already use setup you don't need it.
+
+_This feature is available only on Android._
+
+```js
+RNCallKeep.registerPhoneAccount();
+```
+
+### registerAndroidEvents
+
+Registers Android UI events, useful when you don't want to call `setup()`.
+This method is called by `setup`, if you already use setup you don't need it.
+
+_This feature is available only on Android._
+
+```js
+RNCallKeep.registerAndroidEvents();
 ```
 
 ## Example

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,8 +54,16 @@ export default class RNCallKeep {
   static hasDefaultPhoneAccount(): boolean {
 
   }
-  
+
   static answerIncomingCall(uuid: string) {
+
+  }
+
+  static registerPhoneAccount(): void {
+
+  }
+
+  static registerAndroidEvents(): void {
 
   }
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,21 @@ class RNCallKeep {
     return this._setupIOS(options.ios);
   };
 
+  registerPhoneAccount = () => {
+    if (isIOS) {
+      return;
+    }
+    RNCallKeepModule.registerPhoneAccount();
+  };
+
+
+  registerAndroidEvents = () => {
+    if (isIOS) {
+      return;
+    }
+    RNCallKeepModule.registerEvents();
+  };
+
   hasDefaultPhoneAccount = async (options) => {
     if (!isIOS) {
       return this._hasDefaultPhoneAccount(options);


### PR DESCRIPTION
After reading #221, it seems really interesting to have separate method to register the phone account on Android.

I've splited the `setup()` method on Android into `registerPhoneAccount()` and `registerAndroidEvents()`.
We've the case when the user has disable the phone account, but calling `setup()` always prompt the user to enable it...

By using `registerPhoneAccount()` instead of `setup()` we can now bind the events without prompting the user when the phone account is disabled.

I don't have backported the `checkPhoneAccountEnabled` method from #221 because it's already the job of `hasPhoneAccount`.