### PR TITLE
Video support on incomingCall

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/Constants.java
+++ b/android/src/main/java/io/wazo/callkeep/Constants.java
@@ -16,4 +16,5 @@ public class Constants {
     public static final String EXTRA_CALL_NUMBER = "EXTRA_CALL_NUMBER";
     public static final String EXTRA_CALL_UUID = "EXTRA_CALL_UUID";
     public static final String EXTRA_CALLER_NAME = "EXTRA_CALLER_NAME";
+    public static final String EXTRA_HAS_VIDEO = "EXTRA_HAS_VIDEO";
 }

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -83,6 +83,7 @@ import static io.wazo.callkeep.Constants.ACTION_ONGOING_CALL;
 import static io.wazo.callkeep.Constants.ACTION_AUDIO_SESSION;
 import static io.wazo.callkeep.Constants.ACTION_CHECK_REACHABILITY;
 import static io.wazo.callkeep.Constants.ACTION_WAKE_APP;
+import static io.wazo.callkeep.Constants.EXTRA_HAS_VIDEO;
 
 // @see https://github.com/kbagchiGWC/voice-quickstart-android/blob/9a2aff7fbe0d0a5ae9457b48e9ad408740dfb968/exampleConnectionService/src/main/java/com/twilio/voice/examples/connectionservice/VoiceConnectionServiceActivity.java
 public class RNCallKeepModule extends ReactContextBaseJavaModule {
@@ -148,12 +149,12 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void displayIncomingCall(String uuid, String number, String callerName) {
+    public void displayIncomingCall(String uuid, String number, String callerName, Boolean hasVideo) {
         if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
             return;
         }
 
-        Log.d(TAG, "displayIncomingCall number: " + number + ", callerName: " + callerName);
+        Log.d(TAG, "displayIncomingCall number: " + number + ", callerName: " + callerName + ", hasvideo: " + hasVideo);
 
         Bundle extras = new Bundle();
         Uri uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null);
@@ -161,6 +162,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         extras.putParcelable(TelecomManager.EXTRA_INCOMING_CALL_ADDRESS, uri);
         extras.putString(EXTRA_CALLER_NAME, callerName);
         extras.putString(EXTRA_CALL_UUID, uuid);
+        extras.putBoolean(EXTRA_HAS_VIDEO, hasVideo);
 
         telecomManager.addNewIncomingCall(handle, extras);
     }
@@ -479,7 +481,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         String appName = this.getApplicationName(this.getAppContext());
 
         PhoneAccount.Builder builder = new PhoneAccount.Builder(handle, appName)
-                .setCapabilities(PhoneAccount.CAPABILITY_CALL_PROVIDER);
+                .setCapabilities(PhoneAccount.CAPABILITY_CALL_PROVIDER  | PhoneAccount.CAPABILITY_VIDEO_CALLING);
 
         if (_settings != null && _settings.hasKey("imageName")) {
             int identifier = appContext.getResources().getIdentifier(_settings.getString("imageName"), "drawable", appContext.getPackageName());

--- a/android/src/main/java/io/wazo/callkeep/VideoConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VideoConnectionService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020 The CallKeep Authors (see the AUTHORS file)
+ * SPDX-License-Identifier: ISC, MIT
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package io.wazo.callkeep;
+
+import android.net.Uri;
+import android.telecom.Connection;
+import android.telecom.VideoProfile;
+import android.view.Surface;
+
+import java.lang.String;
+
+
+/**
+ * Implements the VideoCallProvider.
+ */
+public class VideoConnectionService extends Connection.VideoProvider {
+
+    public VideoConnectionService() {
+    }
+
+    @Override
+    public void onSetCamera(String cameraId) {
+    }
+
+    @Override
+    public void onSetPreviewSurface(Surface surface) {
+    }
+
+    @Override
+    public void onSetDisplaySurface(Surface surface) {
+    }
+
+    @Override
+    public void onSetDeviceOrientation(int rotation) {
+    }
+
+    @Override
+    public void onSetZoom(float value) {
+    }
+
+    @Override
+    public void onSendSessionModifyRequest(final VideoProfile fromProfile, final VideoProfile requestProfile) {
+    }
+
+    @Override
+    public void onSendSessionModifyResponse(VideoProfile responseProfile) {
+    }
+
+    @Override
+    public void onRequestCameraCapabilities() {
+    }
+
+    @Override
+    public void onRequestConnectionDataUsage() {
+    }
+
+    @Override
+    public void onSetPauseImage(Uri uri) {
+    }
+
+}

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -92,9 +92,11 @@ public class VoiceConnection extends Connection {
     }
 
     @Override
-    public void onAnswer() {
-        super.onAnswer();
+    public void onAnswer(int videoState) {
+        super.onAnswer(videoState);
         Log.d(TAG, "onAnswer called");
+
+        setVideoState(videoState);
 
         setConnectionCapabilities(getConnectionCapabilities() | Connection.CAPABILITY_HOLD);
         setAudioModeIsVoip(true);

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -35,6 +35,7 @@ import android.telecom.ConnectionService;
 import android.telecom.DisconnectCause;
 import android.telecom.PhoneAccountHandle;
 import android.telecom.TelecomManager;
+import android.telecom.VideoProfile;
 import android.util.Log;
 
 import android.app.ActivityManager;
@@ -58,6 +59,7 @@ import static io.wazo.callkeep.Constants.ACTION_WAKE_APP;
 import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
 import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
 import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
+import static io.wazo.callkeep.Constants.EXTRA_HAS_VIDEO
 
 // @see https://github.com/kbagchiGWC/voice-quickstart-android/blob/9a2aff7fbe0d0a5ae9457b48e9ad408740dfb968/exampleConnectionService/src/main/java/com/twilio/voice/examples/connectionservice/VoiceConnectionService.java
 @TargetApi(Build.VERSION_CODES.M)
@@ -123,7 +125,13 @@ public class VoiceConnectionService extends ConnectionService {
         Bundle extra = request.getExtras();
         Uri number = request.getAddress();
         String name = extra.getString(EXTRA_CALLER_NAME);
+        Boolean hasVideo = extra.getBoolean(EXTRA_HAS_VIDEO, false);
         Connection incomingCallConnection = createConnection(request);
+
+        if (hasVideo) {
+             setVideoCallSupport(incomingCallConnection);
+        }
+
         incomingCallConnection.setRinging();
         incomingCallConnection.setInitialized();
 
@@ -296,6 +304,13 @@ public class VoiceConnectionService extends ConnectionService {
                 LocalBroadcastManager.getInstance(instance).sendBroadcast(intent);
             }
         });
+    }
+
+    private void setVideoCallSupport(Connection connection) {
+        VideoConnectionService VideoCallProvider = new VideoConnectionService();
+
+        connection.setVideoState(VideoProfile.STATE_BIDIRECTIONAL);
+        connection.setVideoProvider(VideoCallProvider);
     }
 
     private HashMap<String, String> bundleToMap(Bundle extras) {


### PR DESCRIPTION
This PR add video support on incomingCall. Video support means when you received a video call, your phone replace the answer button by a video button, add an icon to explain you you are receiving a video call from the caller. This PR add a new arg to displayIncomingCall hasVideo (boolean). I only tested on my pixel phone for the moment and it missed some stuff to work correctly when screen is locked but it works.