### PR TITLE
[iOS] Add support for answering incoming call

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ RNCallKeep.displayIncomingCall(uuid, handle, localizedCallerName);
   - `true` (you know... when not false)
 
 ### answerIncomingCall
-_This feature is available only on Android._
 
 Use this to tell the sdk a user answered a call from the app UI.
 

--- a/index.js
+++ b/index.js
@@ -87,9 +87,7 @@ class RNCallKeep {
   };
 
   answerIncomingCall = (uuid) => {
-    if (!isIOS) {
-      RNCallKeepModule.answerIncomingCall(uuid);
-    }
+    RNCallKeepModule.answerIncomingCall(uuid);
   };
 
   startCall = (uuid, handle, contactIdentifier, handleType = 'number', hasVideo = false ) => {

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -205,6 +205,19 @@ RCT_EXPORT_METHOD(startCall:(NSString *)uuidString
     [self requestTransaction:transaction];
 }
 
+RCT_EXPORT_METHOD(answerIncomingCall:(NSString *)uuidString)
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKeep][answerCall] uuidString = %@", uuidString);
+#endif
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+    CXAnswerCallAction *answerCallAction = [[CXAnswerCallAction alloc] initWithCallUUID:uuid];
+    CXTransaction *transaction = [[CXTransaction alloc] init];
+    [transaction addAction:answerCallAction];
+
+    [self requestTransaction:transaction];
+}
+
 RCT_EXPORT_METHOD(endCall:(NSString *)uuidString)
 {
 #ifdef DEBUG

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -208,7 +208,7 @@ RCT_EXPORT_METHOD(startCall:(NSString *)uuidString
 RCT_EXPORT_METHOD(answerIncomingCall:(NSString *)uuidString)
 {
 #ifdef DEBUG
-    NSLog(@"[RNCallKeep][answerCall] uuidString = %@", uuidString);
+    NSLog(@"[RNCallKeep][answerIncomingCall] uuidString = %@", uuidString);
 #endif
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
     CXAnswerCallAction *answerCallAction = [[CXAnswerCallAction alloc] initWithCallUUID:uuid];


### PR DESCRIPTION
This PR allows answering an incoming call programmatically.

On iOS 14 the UI for incoming calls could be in the form of a banner instead of a full-screen view that the user will have to interact with the system's UI. So, if the end-user answers an incoming call from a custom UI inside the app, there should be a way to also update the system's UI to an "answered" state.