### PR TITLE
Update android-installation.md

### DIFF
--- a/docs/android-installation.md
+++ b/docs/android-installation.md
@@ -72,7 +72,7 @@ public class MainActivity extends ReactActivity {
     <service android:name="io.wazo.callkeep.VoiceConnectionService"
         android:label="Wazo"
         android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE"
-        android:foregroundServiceType="camera|microphone">>
+        android:foregroundServiceType="phoneCall">>
         <intent-filter>
             <action android:name="android.telecom.ConnectionService" />
         </intent-filter>


### PR DESCRIPTION
My Android build fails when including the two permission `camera|microphone`. Looks like the Android API may have changed since this documentation was last updated:

![image](https://user-images.githubusercontent.com/13140065/106831510-e6beb800-6644-11eb-8440-40c29a2d9c22.png)

My development configuration:
react: 16.13.1
react-native: 0.63.2
react-native-callkeep: ^4.0.1
buildToolsVersion = "29.0.2"
minSdkVersion = 24
compileSdkVersion = 29
targetSdkVersion = 29
macOS Big Sur 11.0.1