### PR TITLE
fix: init callKeepProvider asap

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -127,19 +127,12 @@ RCT_EXPORT_MODULE()
     }
 }
 
-- (void) initCallKitProvider:(NSDictionary *)settings {
+- (void) initCallKitProvider {
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][initCallKitProvider]");
 #endif
-    BOOL renewConfiguration = true;
-    if (settings == nil) {
-        // fallback, get the previous saved settings
-        settings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"RNCallKeepSettings"];
-        renewConfiguration = false;
-    }
-    if (renewConfiguration == true || sharedProvider == nil) {
-        sharedProvider = [[CXProvider alloc] initWithConfiguration:[RNCallKeep getProviderConfiguration:settings ]];
-    }
+    settings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"RNCallKeepSettings"];
+    sharedProvider = [[CXProvider alloc] initWithConfiguration:[RNCallKeep getProviderConfiguration:settings ]];
     self.callKeepProvider = sharedProvider;
     [self.callKeepProvider setDelegate:self queue:nil];
 }
@@ -459,7 +452,7 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
     
     RNCallKeep *callKeep = [RNCallKeep allocWithZone: nil];
     if (callKeep.callKeepProvider == nil) {
-        [callKeep initCallKitProvider:nil];
+        [callKeep initCallKitProvider];
     }
     [callKeep.callKeepProvider reportNewIncomingCallWithUUID:uuid update:callUpdate completion:^(NSError * _Nullable error) {
         [callKeep sendEventWithNameWrapper:RNCallKeepDidDisplayIncomingCall body:@{

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -128,6 +128,9 @@ RCT_EXPORT_MODULE()
 }
 
 - (void) initCallKitProvider:(NSDictionary *)settings {
+#ifdef DEBUG
+    NSLog(@"[RNCallKeep][initCallKitProvider]");
+#endif
     BOOL renewConfiguration = true;
     if (settings == nil) {
         // fallback, get the previous saved settings
@@ -150,11 +153,15 @@ RCT_EXPORT_METHOD(setup:(NSDictionary *)options)
     if (self.callKeepCallController == nil) {
         self.callKeepCallController = [[CXCallController alloc] init];
     }
+    NSDictionary *previousSettingsStored = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"RNCallKeepSettings"];
     NSDictionary *settings = [[NSMutableDictionary alloc] initWithDictionary:options];
     // Store settings in NSUserDefault
     [[NSUserDefaults standardUserDefaults] setObject:settings forKey:@"RNCallKeepSettings"];
     [[NSUserDefaults standardUserDefaults] synchronize];
-    [self initCallKitProvider:settings];
+    // compare config and re init callkit provider if there is delta
+    if (![previousSettingsStored isEqualToDictionary:settings]) {
+        [self initCallKitProvider];
+    }
 }
 
 RCT_REMAP_METHOD(checkIfBusy,

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -128,11 +128,13 @@ RCT_EXPORT_MODULE()
 }
 
 - (void) initCallKitProvider {
+    
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][initCallKitProvider]");
 #endif
-    settings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"RNCallKeepSettings"];
-    sharedProvider = [[CXProvider alloc] initWithConfiguration:[RNCallKeep getProviderConfiguration:settings ]];
+    NSDictionary *settings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"RNCallKeepSettings"];
+    sharedProvider = [[CXProvider alloc] initWithConfiguration:[RNCallKeep getProviderConfiguration:settings]];
+    
     self.callKeepProvider = sharedProvider;
     [self.callKeepProvider setDelegate:self queue:nil];
 }

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -55,7 +55,7 @@ RCT_EXPORT_MODULE()
 #endif
     if (self = [super init]) {
         _isStartCallActionEventListenerAdded = NO;
-        _delayedEvents = [NSMutableArray array];
+        if (_delayedEvents == nil) _delayedEvents = [NSMutableArray array];
     }
     return self;
 }
@@ -120,17 +120,25 @@ RCT_EXPORT_MODULE()
     } else {
         NSDictionary *dictionary = @{
             @"name": name,
-            @"data": body
+            @"data": body ? body : @{}
         };
+        if (_delayedEvents == nil) _delayedEvents = [NSMutableArray array];
         [_delayedEvents addObject:dictionary];
     }
 }
 
-+ (void)initCallKitProvider {
-    if (sharedProvider == nil) {
-        NSDictionary *settings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"RNCallKeepSettings"];
-        sharedProvider = [[CXProvider alloc] initWithConfiguration:[RNCallKeep getProviderConfiguration:settings]];
+- (void) initCallKitProvider:(NSDictionary *)settings {
+    BOOL renewConfiguration = true;
+    if (settings == nil) {
+        // fallback, get the previous saved settings
+        settings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"RNCallKeepSettings"];
+        renewConfiguration = false;
     }
+    if (renewConfiguration == true || sharedProvider == nil) {
+        sharedProvider = [[CXProvider alloc] initWithConfiguration:[RNCallKeep getProviderConfiguration:settings ]];
+    }
+    self.callKeepProvider = sharedProvider;
+    [self.callKeepProvider setDelegate:self queue:nil];
 }
 
 RCT_EXPORT_METHOD(setup:(NSDictionary *)options)
@@ -139,16 +147,14 @@ RCT_EXPORT_METHOD(setup:(NSDictionary *)options)
     NSLog(@"[RNCallKeep][setup] options = %@", options);
 #endif
     _version = [[[NSProcessInfo alloc] init] operatingSystemVersion];
-    self.callKeepCallController = [[CXCallController alloc] init];
+    if (self.callKeepCallController == nil) {
+        self.callKeepCallController = [[CXCallController alloc] init];
+    }
     NSDictionary *settings = [[NSMutableDictionary alloc] initWithDictionary:options];
     // Store settings in NSUserDefault
     [[NSUserDefaults standardUserDefaults] setObject:settings forKey:@"RNCallKeepSettings"];
     [[NSUserDefaults standardUserDefaults] synchronize];
-
-    [RNCallKeep initCallKitProvider];
-
-    self.callKeepProvider = sharedProvider;
-    [self.callKeepProvider setDelegate:self queue:nil];
+    [self initCallKitProvider:settings];
 }
 
 RCT_REMAP_METHOD(checkIfBusy,
@@ -443,10 +449,12 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
     callUpdate.supportsUngrouping = supportsUngrouping;
     callUpdate.hasVideo = hasVideo;
     callUpdate.localizedCallerName = localizedCallerName;
-
-    [RNCallKeep initCallKitProvider];
-    [sharedProvider reportNewIncomingCallWithUUID:uuid update:callUpdate completion:^(NSError * _Nullable error) {
-        RNCallKeep *callKeep = [RNCallKeep allocWithZone: nil];
+    
+    RNCallKeep *callKeep = [RNCallKeep allocWithZone: nil];
+    if (callKeep.callKeepProvider == nil) {
+        [callKeep initCallKitProvider:nil];
+    }
+    [callKeep.callKeepProvider reportNewIncomingCallWithUUID:uuid update:callUpdate completion:^(NSError * _Nullable error) {
         [callKeep sendEventWithNameWrapper:RNCallKeepDidDisplayIncomingCall body:@{
             @"error": error && error.localizedDescription ? error.localizedDescription : @"",
             @"callUUID": uuidString,
@@ -503,7 +511,12 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][getProviderConfiguration]");
 #endif
-    CXProviderConfiguration *providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:settings[@"appName"]];
+    NSString *localizedName = @"unknown";
+    if (settings && settings[@"appName"]) {
+        localizedName =settings[@"appName"];
+    }
+    
+    CXProviderConfiguration *providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:localizedName];
     providerConfiguration.supportsVideo = YES;
     providerConfiguration.maximumCallGroups = 3;
     providerConfiguration.maximumCallsPerCallGroup = 1;


### PR DESCRIPTION
1. If incoming call is answered before the `setup` method called from js, the event `RNCallKeepPerformAnswerCallAction` is never triggered. 
2. Init could be called more than once, so the `_delayedEvents` are cleared. 

fix #330 
fix #352 
fix #347
fix #311