### PR TITLE
feat: add getCalls method for ios only

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,13 +187,33 @@ RNCallKeep.isCallActive(uuid);
 - `uuid`: string
   - The `uuid` used for `startCall` or `displayIncomingCall`
 
+
+### getCalls
+
+_This feature is available only on IOS._
+
+Returns a Promise. The result will be an array with all current calls and their states.
+
+```js
+RNCallKeep.getCalls();
+
+response:
+[{
+  callUUID: "E26B14F7-2CDF-48D0-9925-532199AE7C48"
+  hasConnected: true
+  hasEnded: false
+  onHold: false
+  outgoing: false
+}]
+```
+
 ### displayIncomingCall
 
 Display system UI for incoming calls
 
-````js
+```js
 RNCallKeep.displayIncomingCall(uuid, handle, localizedCallerName);
-````
+```
 
 - `uuid`: string
   - An `uuid` that should be stored and re-used for `stopCall`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,6 +105,8 @@ declare module 'react-native-callkeep' {
 
     static isCallActive(uuid: string): Promise<boolean>
 
+    static getCalls(): Promise<object>
+
     /**
      * @description supportConnectionService method is available only on Android.
      */

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { NativeModules, Platform, Alert } from 'react-native';
 
-import { listeners, emit } from './actions'
+import { listeners, emit } from './actions';
 
 const RNCallKeepModule = NativeModules.RNCallKeep;
 const isIOS = Platform.OS === 'ios';
@@ -13,13 +13,13 @@ const CONSTANTS = {
     UNANSWERED: 3,
     ANSWERED_ELSEWHERE: 4,
     DECLINED_ELSEWHERE: isIOS ? 5 : 2, // make declined elsewhere link to "Remote ended" on android because that's kinda true
-    MISSED: isIOS ? 2 : 6  }
+    MISSED: isIOS ? 2 : 6,
+  },
 };
 
 export { CONSTANTS };
 
 class RNCallKeep {
-
   constructor() {
     this._callkeepEventHandlers = new Map();
   }
@@ -55,7 +55,6 @@ class RNCallKeep {
     RNCallKeepModule.registerPhoneAccount();
   };
 
-
   registerAndroidEvents = () => {
     if (isIOS) {
       return;
@@ -71,7 +70,14 @@ class RNCallKeep {
     return;
   };
 
-  displayIncomingCall = (uuid, handle, localizedCallerName = '', handleType = 'number', hasVideo = false, options = null) => {
+  displayIncomingCall = (
+    uuid,
+    handle,
+    localizedCallerName = '',
+    handleType = 'number',
+    hasVideo = false,
+    options = null
+  ) => {
     if (!isIOS) {
       RNCallKeepModule.displayIncomingCall(uuid, handle, localizedCallerName);
       return;
@@ -83,7 +89,17 @@ class RNCallKeep {
     let supportsGrouping = !!(options?.ios?.supportsGrouping ?? true);
     let supportsUngrouping = !!(options?.ios?.supportsUngrouping ?? true);
 
-    RNCallKeepModule.displayIncomingCall(uuid, handle, handleType, hasVideo, localizedCallerName, supportsHolding, supportsDTMF, supportsGrouping, supportsUngrouping);
+    RNCallKeepModule.displayIncomingCall(
+      uuid,
+      handle,
+      handleType,
+      hasVideo,
+      localizedCallerName,
+      supportsHolding,
+      supportsDTMF,
+      supportsGrouping,
+      supportsUngrouping
+    );
   };
 
   answerIncomingCall = (uuid) => {
@@ -92,7 +108,7 @@ class RNCallKeep {
     }
   };
 
-  startCall = (uuid, handle, contactIdentifier, handleType = 'number', hasVideo = false ) => {
+  startCall = (uuid, handle, contactIdentifier, handleType = 'number', hasVideo = false) => {
     if (!isIOS) {
       RNCallKeepModule.startCall(uuid, handle, contactIdentifier);
       return;
@@ -107,7 +123,7 @@ class RNCallKeep {
     }
 
     return RNCallKeepModule.checkPhoneAccountEnabled();
-  }
+  };
 
   isConnectionServiceAvailable = async () => {
     if (isIOS) {
@@ -115,7 +131,7 @@ class RNCallKeep {
     }
 
     return RNCallKeepModule.isConnectionServiceAvailable();
-  }
+  };
 
   reportConnectingOutgoingCallWithUUID = (uuid) => {
     //only available on iOS
@@ -145,7 +161,13 @@ class RNCallKeep {
     }
   };
 
-  isCallActive = async(uuid) => await RNCallKeepModule.isCallActive(uuid);
+  isCallActive = async (uuid) => await RNCallKeepModule.isCallActive(uuid);
+
+  getCalls = () => {
+    if (isIOS) {
+      return RNCallKeepModule.getCalls();
+    }
+  };
 
   endCall = (uuid) => RNCallKeepModule.endCall(uuid);
 
@@ -153,11 +175,9 @@ class RNCallKeep {
 
   supportConnectionService = () => supportConnectionService;
 
-  hasPhoneAccount = async () =>
-    isIOS ? true : await RNCallKeepModule.hasPhoneAccount();
+  hasPhoneAccount = async () => (isIOS ? true : await RNCallKeepModule.hasPhoneAccount());
 
-  hasOutgoingCall = async () =>
-    isIOS ? null : await RNCallKeepModule.hasOutgoingCall();
+  hasOutgoingCall = async () => (isIOS ? null : await RNCallKeepModule.hasOutgoingCall());
 
   setMutedCall = (uuid, shouldMute) => {
     RNCallKeepModule.setMutedCall(uuid, shouldMute);
@@ -166,14 +186,10 @@ class RNCallKeep {
   sendDTMF = (uuid, key) => RNCallKeepModule.sendDTMF(uuid, key);
 
   checkIfBusy = () =>
-    isIOS
-      ? RNCallKeepModule.checkIfBusy()
-      : Promise.reject('RNCallKeep.checkIfBusy was called from unsupported OS');
+    isIOS ? RNCallKeepModule.checkIfBusy() : Promise.reject('RNCallKeep.checkIfBusy was called from unsupported OS');
 
   checkSpeaker = () =>
-    isIOS
-      ? RNCallKeepModule.checkSpeaker()
-      : Promise.reject('RNCallKeep.checkSpeaker was called from unsupported OS');
+    isIOS ? RNCallKeepModule.checkSpeaker() : Promise.reject('RNCallKeep.checkSpeaker was called from unsupported OS');
 
   setAvailable = (state) => {
     if (isIOS) {
@@ -220,7 +236,7 @@ class RNCallKeep {
     if (options && options.ios) {
       iosOptions = {
         ...options.ios,
-      }
+      };
     }
     RNCallKeepModule.updateDisplay(uuid, displayName, handle, iosOptions);
   };
@@ -238,16 +254,17 @@ class RNCallKeep {
       : Promise.reject('RNCallKeep.reportUpdatedCall was called from unsupported OS');
   };
 
-  _setupIOS = async (options) => new Promise((resolve, reject) => {
-    if (!options.appName) {
-      reject('RNCallKeep.setup: option "appName" is required');
-    }
-    if (typeof options.appName !== 'string') {
-      reject('RNCallKeep.setup: option "appName" should be of type "string"');
-    }
+  _setupIOS = async (options) =>
+    new Promise((resolve, reject) => {
+      if (!options.appName) {
+        reject('RNCallKeep.setup: option "appName" is required');
+      }
+      if (typeof options.appName !== 'string') {
+        reject('RNCallKeep.setup: option "appName" should be of type "string"');
+      }
 
-    resolve(RNCallKeepModule.setup(options));
-  });
+      resolve(RNCallKeepModule.setup(options));
+    });
 
   _setupAndroid = async (options) => {
     RNCallKeepModule.setup(options);
@@ -272,27 +289,26 @@ class RNCallKeep {
     }
   };
 
-  _alert = async (options, condition) => new Promise((resolve, reject) => {
-    if (!condition) {
-      return resolve(false);
-    }
+  _alert = async (options, condition) =>
+    new Promise((resolve, reject) => {
+      if (!condition) {
+        return resolve(false);
+      }
 
-    Alert.alert(
-      options.alertTitle,
-      options.alertDescription,
-      [
-        {
-          text: options.cancelButton,
-          onPress: reject,
-          style: 'cancel',
-        },
-        { text: options.okButton,
-          onPress: () => resolve(true)
-        },
-      ],
-      { cancelable: true },
-    );
-  });
+      Alert.alert(
+        options.alertTitle,
+        options.alertDescription,
+        [
+          {
+            text: options.cancelButton,
+            onPress: reject,
+            style: 'cancel',
+          },
+          { text: options.okButton, onPress: () => resolve(true) },
+        ],
+        { cancelable: true }
+      );
+    });
 
   backToForeground() {
     if (isIOS) {
@@ -301,7 +317,6 @@ class RNCallKeep {
 
     NativeModules.RNCallKeep.backToForeground();
   }
-
 }
 
 export default new RNCallKeep();

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -343,6 +343,15 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
     [RNCallKeep isCallActive: uuidString];
 }
 
+RCT_EXPORT_METHOD(getCalls:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKeep][getCalls]");
+#endif
+    resolve([RNCallKeep getCalls]);
+}
+
 - (void)requestTransaction:(CXTransaction *)transaction
 {
 #ifdef DEBUG
@@ -386,6 +395,27 @@ RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString)
         }
     }
     return false;
+}
+
++ (NSMutableArray *) getCalls
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKeep][getCalls]");
+#endif
+    CXCallObserver *callObserver = [[CXCallObserver alloc] init];
+    NSMutableArray *currentCalls = [NSMutableArray array];
+    for(CXCall *call in callObserver.calls){
+        NSString *uuidString = [call.UUID UUIDString];
+        NSDictionary *requestedCall= @{
+           @"callUUID": uuidString,
+           @"outgoing": call.outgoing? @YES : @NO,
+           @"onHold": call.onHold? @YES : @NO,
+           @"hasConnected": call.hasConnected ? @YES : @NO,
+           @"hasEnded": call.hasEnded ? @YES : @NO
+        };
+        [currentCalls addObject:requestedCall];
+    }
+    return currentCalls;
 }
 
 + (void)endCallWithUUID:(NSString *)uuidString


### PR DESCRIPTION
### getCalls

_This feature is available only on IOS._

Returns a Promise. The result will be an array with all current calls and their states.

```js
RNCallKeep.getCalls();

response:
[{
  callUUID: "E26B14F7-2CDF-48D0-9925-532199AE7C48"
  hasConnected: true
  hasEnded: false
  onHold: false
  outgoing: false
}]
```