### PR TITLE
androidx import

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -33,7 +33,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.speech.tts.Voice;
 import androidx.annotation.Nullable;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.telecom.CallAudioState;
 import android.telecom.Connection;


### PR DESCRIPTION
There was attempt to move to androidx here, https://github.com/react-native-webrtc/react-native-callkeep/pull/210 , this is in master but it was broken in https://github.com/react-native-webrtc/react-native-callkeep/pull/321 with app compat import ...

this PR brings it back to androidx compatible

cc @manuquentin