### PR TITLE
Fixing types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,17 @@ declare module 'react-native-callkeep' {
   export type DidDisplayIncomingCallPayload = string | undefined;
   export type DidPerformSetMutedCallActionPayload = boolean;
 
+  export const CONSTANTS: {
+    END_CALL_REASONS: {
+      FAILED: 1,
+      REMOTE_ENDED: 2,
+      UNANSWERED: 3,
+      ANSWERED_ELSEWHERE: 4,
+      DECLINED_ELSEWHERE: 5 | 2,
+      MISSED: 2 | 6
+    }
+  };
+
   export default class RNCallKeep {
     static addEventListener(type: Events, handler: (args: any) => void): void
 


### PR DESCRIPTION
The CONSTANTS were not in the typescript definition. This simply adds them.

To recreate the issue, in any typescript file:

```typescript
import {CONSTANTS} from 'react-native-callkeep';
console.log(CONSTANTS);
```

eslint or tsc will complain about the types not being there