### PR TITLE
Avoid to check for reachability everytime we make a call

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -122,7 +122,9 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setup(ReadableMap options) {
+        Log.d(TAG, "setup");
         VoiceConnectionService.setAvailable(false);
+        VoiceConnectionService.setInitialized(true);
         this._settings = options;
 
         if (isConnectionServiceAvailable()) {

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -142,6 +142,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
             return;
         }
 
+        Log.d(TAG, "registerPhoneAccount");
+
         this.registerPhoneAccount(this.getAppContext());
     }
 
@@ -162,7 +164,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        Log.d(TAG, "displayIncomingCall number: " + number + ", callerName: " + callerName);
+        Log.d(TAG, "displayIncomingCall, uuid: " + uuid + ", number: " + number + ", callerName: " + callerName);
 
         Bundle extras = new Bundle();
         Uri uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null);
@@ -176,6 +178,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void answerIncomingCall(String uuid) {
+        Log.d(TAG, "answerIncomingCall, uuid: " + uuid);
         if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
             return;
         }
@@ -190,11 +193,11 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void startCall(String uuid, String number, String callerName) {
+        Log.d(TAG, "startCall called, uuid: " + uuid + ", number: " + number + ", callerName: " + callerName);
+
         if (!isConnectionServiceAvailable() || !hasPhoneAccount() || !hasPermissions() || number == null) {
             return;
         }
-
-        Log.d(TAG, "startCall number: " + number + ", callerName: " + callerName);
 
         Bundle extras = new Bundle();
         Uri uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, number, null);
@@ -207,12 +210,14 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         extras.putParcelable(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE, handle);
         extras.putParcelable(TelecomManager.EXTRA_OUTGOING_CALL_EXTRAS, callExtras);
 
+        Log.d(TAG, "startCall, uuid: " + uuid);
+
         telecomManager.placeCall(uri, extras);
     }
 
     @ReactMethod
     public void endCall(String uuid) {
-        Log.d(TAG, "endCall called");
+        Log.d(TAG, "endCall called, uuid: " + uuid);
         if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
             return;
         }
@@ -223,7 +228,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         }
         conn.onDisconnect();
 
-        Log.d(TAG, "endCall executed");
+        Log.d(TAG, "endCall executed, uuid: " + uuid);
     }
 
     @ReactMethod
@@ -362,6 +367,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setOnHold(String uuid, boolean shouldHold) {
+        Log.d(TAG, "setOnHold, uuid: " + uuid + ", shouldHold: " + (shouldHold ? "true" : "false"));
+
         Connection conn = VoiceConnectionService.getConnection(uuid);
         if (conn == null) {
             return;
@@ -376,6 +383,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void reportEndCallWithUUID(String uuid, int reason) {
+        Log.d(TAG, "reportEndCallWithUUID, uuid: " + uuid + ", reason: " + reason);
         if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
             return;
         }
@@ -389,6 +397,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void rejectCall(String uuid) {
+        Log.d(TAG, "rejectCall, uuid: " + uuid);
         if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
             return;
         }
@@ -403,6 +412,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setMutedCall(String uuid, boolean shouldMute) {
+        Log.d(TAG, "setMutedCall, uuid: " + uuid + ", shouldMute: " + (shouldMute ? "true" : "false"));
         Connection conn = VoiceConnectionService.getConnection(uuid);
         if (conn == null) {
             return;
@@ -422,6 +432,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void sendDTMF(String uuid, String key) {
+        Log.d(TAG, "sendDTMF, uuid: " + uuid + ", key: " + key);
         Connection conn = VoiceConnectionService.getConnection(uuid);
         if (conn == null) {
             return;
@@ -432,6 +443,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void updateDisplay(String uuid, String displayName, String uri) {
+        Log.d(TAG, "updateDisplay, uuid: " + uuid + ", displayName: " + displayName+ ", uri: " + uri);
         Connection conn = VoiceConnectionService.getConnection(uuid);
         if (conn == null) {
             return;
@@ -482,6 +494,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setCurrentCallActive(String uuid) {
+        Log.d(TAG, "setCurrentCallActive, uuid: " + uuid);
         Connection conn = VoiceConnectionService.getConnection(uuid);
         if (conn == null) {
             return;

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -133,6 +133,8 @@ public class VoiceConnectionService extends ConnectionService {
         Log.d(TAG, "deinitConnection:" + connectionId);
         VoiceConnectionService.hasOutgoingCall = false;
 
+        currentConnectionService.stopForegroundService();
+
         if (currentConnections.containsKey(connectionId)) {
             currentConnections.remove(connectionId);
         }
@@ -258,6 +260,15 @@ public class VoiceConnectionService extends ConnectionService {
 
         Notification notification = notificationBuilder.build();
         startForeground(FOREGROUND_SERVICE_TYPE_MICROPHONE, notification);
+    }
+
+    private void stopForegroundService() {
+        Log.d(TAG, "stopForegroundService");
+        if (_settings == null || !_settings.hasKey("foregroundService")) {
+            Log.d(TAG, "Discarding stop foreground service, no service configured");
+            return;
+        }
+        stopForeground(FOREGROUND_SERVICE_TYPE_MICROPHONE);
     }
 
     private void wakeUpApplication(String uuid, String number, String displayName) {

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -252,6 +252,11 @@ public class VoiceConnectionService extends ConnectionService {
     }
 
     private void wakeUpApplication(String uuid, String number, String displayName) {
+         Log.d(TAG, "wakeUpApplication, uuid:" + uuid + ", number :" + number + ", displayName:" + displayName);
+
+        // Avoid to call wake up the app again in wakeUpAfterReachabilityTimeout.
+        this.currentConnectionRequest = null;
+
         Intent headlessIntent = new Intent(
             this.getApplicationContext(),
             RNCallKeepBackgroundMessagingService.class

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -143,6 +143,9 @@ public class VoiceConnectionService extends ConnectionService {
         Bundle extra = request.getExtras();
         Uri number = request.getAddress();
         String name = extra.getString(EXTRA_CALLER_NAME);
+
+        Log.d(TAG, "onCreateIncomingConnection, name:" + name);
+
         Connection incomingCallConnection = createConnection(request);
         incomingCallConnection.setRinging();
         incomingCallConnection.setInitialized();
@@ -156,6 +159,8 @@ public class VoiceConnectionService extends ConnectionService {
     public Connection onCreateOutgoingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
         VoiceConnectionService.hasOutgoingCall = true;
         String uuid = UUID.randomUUID().toString();
+
+        Log.d(TAG, "onCreateOutgoingConnection, uuid:" + uuid);
 
         if (!isInitialized && !isReachable) {
             this.notReachableCallUuid = uuid;
@@ -174,7 +179,7 @@ public class VoiceConnectionService extends ConnectionService {
         String displayName = extras.getString(EXTRA_CALLER_NAME);
         Boolean isForeground = VoiceConnectionService.isRunning(this.getApplicationContext());
 
-        Log.d(TAG, "makeOutgoingCall:" + uuid + ", number: " + number + ", displayName:" + displayName);
+        Log.d(TAG, "makeOutgoingCall, uuid:" + uuid + ", number: " + number + ", displayName:" + displayName);
 
         // Wakeup application if needed
         if (!isForeground || forceWakeUp) {
@@ -224,6 +229,7 @@ public class VoiceConnectionService extends ConnectionService {
             // Foreground services not required before SDK 28
             return;
         }
+        Log.d(TAG, "startForegroundService");
         if (_settings == null || !_settings.hasKey("foregroundService")) {
             Log.d(TAG, "Not creating foregroundService because not configured");
             return;
@@ -307,6 +313,8 @@ public class VoiceConnectionService extends ConnectionService {
     }
 
     private Connection createConnection(ConnectionRequest request) {
+        Log.d(TAG, "createConnection");
+
         Bundle extras = request.getExtras();
         HashMap<String, String> extrasMap = this.bundleToMap(extras);
         extrasMap.put(EXTRA_CALL_NUMBER, request.getAddress().toString());
@@ -331,6 +339,7 @@ public class VoiceConnectionService extends ConnectionService {
 
     @Override
     public void onConference(Connection connection1, Connection connection2) {
+        Log.d(TAG, "onConference");
         super.onConference(connection1, connection2);
         VoiceConnection voiceConnection1 = (VoiceConnection) connection1;
         VoiceConnection voiceConnection2 = (VoiceConnection) connection2;
@@ -351,6 +360,8 @@ public class VoiceConnectionService extends ConnectionService {
     private void sendCallRequestToActivity(final String action, @Nullable final HashMap attributeMap) {
         final VoiceConnectionService instance = this;
         final Handler handler = new Handler();
+
+        Log.d(TAG, "sendCallRequestToActivity, action:" + action);
 
         handler.post(new Runnable() {
             @Override
@@ -391,9 +402,12 @@ public class VoiceConnectionService extends ConnectionService {
         List<RunningTaskInfo> tasks = activityManager.getRunningTasks(Integer.MAX_VALUE);
 
         for (RunningTaskInfo task : tasks) {
-            if (context.getPackageName().equalsIgnoreCase(task.baseActivity.getPackageName()))
+            if (context.getPackageName().equalsIgnoreCase(task.baseActivity.getPackageName())) {
                 return true;
+            }
         }
+
+        Log.d(TAG, "isRunning: no running package found.");
 
         return false;
     }

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -69,9 +69,9 @@ import static io.wazo.callkeep.Constants.FOREGROUND_SERVICE_TYPE_MICROPHONE;
 // @see https://github.com/kbagchiGWC/voice-quickstart-android/blob/9a2aff7fbe0d0a5ae9457b48e9ad408740dfb968/exampleConnectionService/src/main/java/com/twilio/voice/examples/connectionservice/VoiceConnectionService.java
 @TargetApi(Build.VERSION_CODES.M)
 public class VoiceConnectionService extends ConnectionService {
-    private static Boolean isAvailable;
-    private static Boolean isInitialized;
-    private static Boolean isReachable;
+    private static Boolean isAvailable = false;
+    private static Boolean isInitialized = false;
+    private static Boolean isReachable = false;
     private static Boolean canMakeMultipleCalls = true;
     private static String notReachableCallUuid;
     private static ConnectionRequest currentConnectionRequest;
@@ -92,9 +92,6 @@ public class VoiceConnectionService extends ConnectionService {
     public VoiceConnectionService() {
         super();
         Log.e(TAG, "Constructor");
-        isReachable = false;
-        isInitialized = false;
-        isAvailable = false;
         currentConnectionRequest = null;
         currentConnectionService = this;
     }
@@ -106,7 +103,7 @@ public class VoiceConnectionService extends ConnectionService {
     public static void setAvailable(Boolean value) {
         Log.d(TAG, "setAvailable: " + (value ? "true" : "false"));
         if (value) {
-            isInitialized = true;
+            setInitialized(true);
         }
 
         isAvailable = value;
@@ -124,6 +121,12 @@ public class VoiceConnectionService extends ConnectionService {
         Log.d(TAG, "setReachable");
         isReachable = true;
         VoiceConnectionService.currentConnectionRequest = null;
+    }
+
+    public static void setInitialized(boolean value) {
+        Log.d(TAG, "setInitialized: " + (value ? "true" : "false"));
+
+        isInitialized = value;
     }
 
     public static void deinitConnection(String connectionId) {


### PR DESCRIPTION
This PR changes the way we check for reachability.
Instead of setting `isReachable` to false in the `VoiceConnectionService` constructor, we set it to false in the module constructor.

The `VoiceConnectionService` constructor is called each time a call is made, we don't have to reset the `isReachable` boolean, because when the JS bridge is reachable once in the module lifetime there is no need to check it again.

This PR adds more logs and more information in logs.

This PR also fixes the `wakeUpApplication` which can be called twice when the reachability timeout is triggered.