### PR TITLE
Export emit to ease didLoadWithEvents handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const CONSTANTS = {
   },
 };
 
-export { CONSTANTS };
+export { emit, CONSTANTS };
 
 class RNCallKeep {
   constructor() {


### PR DESCRIPTION
Currently I use the `emit` function in `react-native-callkeep/actions` to re-emit events picked up by `didLoadWithEvents`.

This PR exports `emit` from `index.js` to allow importing from `react-native-callkeep` directly.

```js
import { emit } from 'react-native-callkeep/actions';

RNCallKit.addEventListener('didLoadWithEvents', (events: EventType[] = []) => {
  console.log('RNCallKit didLoadWithEvents', events);
  for (const { name, data } of events) {
    emit(name, data);
  }
});
```