### PR TITLE
Support IOS setup in AppDelegate.m

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ const options = {
 RNCallKeep.setup(options).then(accepted => {});
 ```
 
+iOS only.
+
+Alternative on iOS you can perform setup in `AppDelegate.m`. Doing this allows capturing events prior to the react native event bridge being up. Please be aware that calling setup in `AppDelegate.m` will ignore any subsequent calls to `RNCallKeep.setup();`.
+
+```objective-c
+@implementation AppDelegate
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{ 
+  self.bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+
+  [RNCallKeep setup:@{
+    @"appName": @"Awesome App",
+    @"maximumCallGroups": @3,
+    @"maximumCallsPerCallGroup": @1,
+    @"supportsVideo": @NO,
+  }];
+
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge
+                                                   moduleName:@"App"
+                                            initialProperties:nil];
+
+  // ======== OTHER CODE REDACTED ==========
+
+  return YES;
+}
+
+```
+
 - `options`: Object
   - `ios`: object
     - `appName`: string (required)
@@ -93,7 +121,7 @@ RNCallKeep.setup(options).then(accepted => {});
     - `additionalPermissions`: [PermissionsAndroid] (optional)
       Any additional permissions you'd like your app to have at first launch. Can be used to simplify permission flows and avoid
       multiple popups to the user at different times.
-      
+
 `setup` calls internally `registerPhoneAccount` and `registerEvents`.
 
 ## Constants
@@ -640,6 +668,8 @@ iOS only.
 Called as soon as JS context initializes if there were some actions performed by user before JS context has been created.
 
 Since iOS 13, you must display incoming call on receiving PushKit push notification. But if app was killed, it takes some time to create JS context. If user answers the call (or ends it) before JS context has been initialized, user actions will be passed as events array of this event. Similar situation can happen if user would like to start a call from Recents or similar iOS app, assuming that your app was in killed state.
+
+In order for this event to reliably fire, it's necessary to perform setup in `AppDelegate.m`
 
 **NOTE: You still need to subscribe / handle the rest events as usuall. This is just a helper whcih cache and propagate early fired events if and only if for "the native events which DID fire BEFORE js bridge is initialed", it does NOT mean this will have events each time when the app reopened.**
 

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -45,4 +45,6 @@ continueUserActivity:(NSUserActivity *)userActivity
 
 + (BOOL)isCallActive:(NSString *)uuidString;
 
++ (void)setup:(NSDictionary *)options;
+
 @end

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -12,6 +12,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTUtils.h>
+#import <React/RCTLog.h>
 
 #import <AVFoundation/AVAudioSession.h>
 
@@ -41,9 +42,9 @@ static NSString *const RNCallKeepDidLoadWithEvents = @"RNCallKeepDidLoadWithEven
     BOOL _isStartCallActionEventListenerAdded;
     bool _hasListeners;
     NSMutableArray *_delayedEvents;
-    bool _isSetup;
 }
 
+static bool isSetupNatively;
 static CXProvider* sharedProvider;
 
 // should initialise in AppDelegate.m
@@ -138,13 +139,15 @@ RCT_EXPORT_MODULE()
 + (void)setup:(NSDictionary *)options {
     RNCallKeep *callKeep = [RNCallKeep allocWithZone: nil];
     [callKeep setup:options];
+    isSetupNatively = YES;
 }
 
 RCT_EXPORT_METHOD(setup:(NSDictionary *)options)
 {
-    if (_isSetup) {
+    if (isSetupNatively) {
 #ifdef DEBUG
         NSLog(@"[RNCallKeep][setup] already setup");
+        RCTLog(@"[RNCallKeep][setup] already setup in native code");
 #endif
         return;
     }
@@ -163,8 +166,6 @@ RCT_EXPORT_METHOD(setup:(NSDictionary *)options)
 
     self.callKeepProvider = sharedProvider;
     [self.callKeepProvider setDelegate:self queue:nil];
-    
-    _isSetup = YES;
 }
 
 RCT_REMAP_METHOD(checkIfBusy,

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -55,10 +55,8 @@ RCT_EXPORT_MODULE()
     NSLog(@"[RNCallKeep][init]");
 #endif
     if (self = [super init]) {
-        if (_delayedEvents == nil) {
-            _isStartCallActionEventListenerAdded = NO;
-            _delayedEvents = [NSMutableArray array];
-        }
+        _isStartCallActionEventListenerAdded = NO;
+        if (_delayedEvents == nil) _delayedEvents = [NSMutableArray array];
     }
     return self;
 }
@@ -122,9 +120,10 @@ RCT_EXPORT_MODULE()
         [self sendEventWithName:name body:body];
     } else {
         NSDictionary *dictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-                              name, @"name",
-                              body, @"data",
-                              nil];
+            name, @"name",
+            body, @"data",
+            nil
+        ];
         [_delayedEvents addObject:dictionary];
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-callkeep",
-  "version": "4.1.1-iosfix",
+  "version": "4.1.0",
   "description": "iOS 10 CallKit and Android ConnectionService Framework For React Native",
   "main": "index.js",
   "scripts": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-callkeep",
-  "version": "4.1.0",
+  "version": "4.1.1-iosfix",
   "description": "iOS 10 CallKit and Android ConnectionService Framework For React Native",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
On IOS, CallKit doesn't get it's delegate registered before actively calling .setup from react native, meaning that we'll never get any didLoadWithEvents fired for events such as answer and end, since CallKit simply isn't delegated to callkeep prior answering the call.

This PR exposes setup so it can be called from AppDelegate.m, allowing us to catch these events as soon as they happen.

Example of how to perform setup during AppDelegate initialization:
```
@implementation AppDelegate
- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
{ 
  self.bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];

  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge
                                                   moduleName:@"App"
                                            initialProperties:nil];

  // ======== OTHER CODE REDACTED ==========

  // RNCallKeep setup should (probably?) be called before registering for PuskKit notifications
  [RNCallKeep setup:@{
    @"appName": @"Awesome App",
    @"maximumCallGroups": @3,
    @"maximumCallsPerCallGroup": @1,
    @"supportsVideo": @NO,
  }];

  // Register for pushkit. As soon as the delegates are registered, Pushkit events will fire.
  // It probably(?) doesn't happen syncronously, but RNCallKeep should probably be registered first
  [RNVoipPushNotificationManager voipRegistration];

  // ======== OTHER CODE REDACTED ==========
  
  return YES;
}
```