### PR TITLE
Implemented self managed mode support for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ RNCallKeep.setup(options).then(accepted => {});
     - `additionalPermissions`: [PermissionsAndroid] (optional)
       Any additional permissions you'd like your app to have at first launch. Can be used to simplify permission flows and avoid
       multiple popups to the user at different times.
+    - `selfManaged`: boolean (optional)
+      When set to true, call keep will configure itself to run as a self managed connection service. This is an advanced topic, and it's best to refer to [Googles Documentation](https://developer.android.com/guide/topics/connectivity/telecom/selfManaged) on the matter.
       
 `setup` calls internally `registerPhoneAccount` and `registerEvents`.
 
@@ -657,6 +659,27 @@ RNCallKeep.addEventListener('didLoadWithEvents', (events) => {
     Native event name like: `RNCallKeepPerformAnswerCallAction`
   - `data`: object
     Object with data passed together with specific event so it can be handled in the same way like original event, for example `({ callUUID })` for `answerCall` event if `name` is `RNCallKeepPerformAnswerCallAction`
+
+### - showIncomingCallUi
+
+Android only.
+
+Only when CallKeep is setup to be in self managed mode. Signals that the app must show an incoming call UI. The implementor must either call `displayIncomingCall` from react native or native android code to make this event fire.
+
+```js
+RNCallKeep.addEventListener('showIncomingCallUi', ({ handle, callUUID, name }) => {
+
+});
+```
+
+The following values will match those initially passed to `displayIncomingCall`
+
+- `handle` (string)
+  - Phone number of the incoming caller.
+- `callUUID` (string)
+  - The UUID of the call.
+- `name` (string)
+  - Caller Name.
 
 ### - checkReachability
 

--- a/actions.js
+++ b/actions.js
@@ -15,6 +15,7 @@ const RNCallKeepDidPerformDTMFAction = 'RNCallKeepDidPerformDTMFAction';
 const RNCallKeepProviderReset = 'RNCallKeepProviderReset';
 const RNCallKeepCheckReachability = 'RNCallKeepCheckReachability';
 const RNCallKeepDidLoadWithEvents = 'RNCallKeepDidLoadWithEvents';
+const RNCallKeepShowIncomingCallUi = 'RNCallKeepShowIncomingCallUi';
 const isIOS = Platform.OS === 'ios';
 
 const didReceiveStartCallAction = handler => {
@@ -59,6 +60,9 @@ const checkReachability = handler =>
 const didLoadWithEvents = handler =>
   eventEmitter.addListener(RNCallKeepDidLoadWithEvents, handler);
 
+const showIncomingCallUi = handler =>
+  eventEmitter.addListener(RNCallKeepShowIncomingCallUi, (data) => handler(data));
+
 export const emit = (eventName, payload) => eventEmitter.emit(eventName, payload);
 
 export const listeners = {
@@ -74,4 +78,5 @@ export const listeners = {
   didResetProvider,
   checkReachability,
   didLoadWithEvents,
+  showIncomingCallUi
 };

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,4 +5,6 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE"
                      android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+    <uses-permission android:name="android.permission.READ_CALL_LOG" />
 </manifest>

--- a/android/src/main/java/io/wazo/callkeep/Constants.java
+++ b/android/src/main/java/io/wazo/callkeep/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
     public static final String ACTION_UNHOLD_CALL = "ACTION_UNHOLD_CALL";
     public static final String ACTION_UNMUTE_CALL = "ACTION_UNMUTE_CALL";
     public static final String ACTION_WAKE_APP = "ACTION_WAKE_APP";
+    public static final String ACTION_SHOW_INCOMING_CALL_UI = "ACTION_SHOW_INCOMING_CALL_UI";
 
     public static final String EXTRA_CALL_NUMBER = "EXTRA_CALL_NUMBER";
     public static final String EXTRA_CALL_UUID = "EXTRA_CALL_UUID";

--- a/android/src/main/java/io/wazo/callkeep/Constants.java
+++ b/android/src/main/java/io/wazo/callkeep/Constants.java
@@ -15,6 +15,7 @@ public class Constants {
     public static final String ACTION_SHOW_INCOMING_CALL_UI = "ACTION_SHOW_INCOMING_CALL_UI";
 
     public static final String EXTRA_CALL_NUMBER = "EXTRA_CALL_NUMBER";
+    public static final String EXTRA_CALL_NUMBER_SCHEMA = "EXTRA_CALL_NUMBER_SCHEMA";
     public static final String EXTRA_CALL_UUID = "EXTRA_CALL_UUID";
     public static final String EXTRA_CALLER_NAME = "EXTRA_CALLER_NAME";
     // Can't use telecom.EXTRA_DISABLE_ADD_CALL ...

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -48,6 +48,7 @@ import static io.wazo.callkeep.Constants.ACTION_UNMUTE_CALL;
 import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
 import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
 import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
+import static io.wazo.callkeep.Constants.ACTION_SHOW_INCOMING_CALL_UI;
 
 @TargetApi(Build.VERSION_CODES.M)
 public class VoiceConnection extends Connection {
@@ -194,6 +195,12 @@ public class VoiceConnection extends Connection {
             Log.e(TAG, "Handle map error", exception);
         }
         destroy();
+    }
+
+    @Override
+    public void onShowIncomingCallUi() {
+        Log.d(TAG, "onShowIncomingCallUi()");
+        sendCallRequestToActivity(ACTION_SHOW_INCOMING_CALL_UI, handle);
     }
 
     /*

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -63,6 +63,7 @@ import static io.wazo.callkeep.Constants.ACTION_CHECK_REACHABILITY;
 import static io.wazo.callkeep.Constants.ACTION_WAKE_APP;
 import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
 import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
+import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER_SCHEMA;
 import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
 import static io.wazo.callkeep.Constants.EXTRA_DISABLE_ADD_CALL;
 import static io.wazo.callkeep.Constants.FOREGROUND_SERVICE_TYPE_MICROPHONE;
@@ -329,7 +330,21 @@ public class VoiceConnectionService extends ConnectionService {
 
         Bundle extras = request.getExtras();
         HashMap<String, String> extrasMap = this.bundleToMap(extras);
-        extrasMap.put(EXTRA_CALL_NUMBER, request.getAddress().toString());
+
+        String callerNumber = request.getAddress().toString();
+        if (callerNumber.contains(":")) {
+            //CallerNumber contains a schema which we'll separate out
+            int schemaIndex = callerNumber.indexOf(":");
+            String number = callerNumber.substring(schemaIndex + 1);
+            String schema = callerNumber.substring(0, schemaIndex);
+
+            extrasMap.put(EXTRA_CALL_NUMBER, number);
+            extrasMap.put(EXTRA_CALL_NUMBER_SCHEMA, schema);
+        }
+        else {
+            extrasMap.put(EXTRA_CALL_NUMBER, callerNumber);
+        }
+
         VoiceConnection connection = new VoiceConnection(this, extrasMap);
         connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE | Connection.CAPABILITY_SUPPORT_HOLD);
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,8 @@ declare module 'react-native-callkeep' {
     'didResetProvider' |
     'checkReachability' |
     'didPerformSetMutedCallAction' |
-    'didLoadWithEvents';
+    'didLoadWithEvents' |
+    'showIncomingCallUi';
 
   type HandleType = 'generic' | 'number' | 'email';
 
@@ -32,6 +33,7 @@ declare module 'react-native-callkeep' {
       okButton: string,
       imageName?: string,
       additionalPermissions: string[],
+      selfManaged?: boolean,
       foregroundService?: {
         channelId: string,
         channelName: string,

--- a/index.js
+++ b/index.js
@@ -274,6 +274,10 @@ class RNCallKeep {
   _setupAndroid = async (options) => {
     RNCallKeepModule.setup(options);
 
+    if (options.selfManaged) {
+      return false;
+    }
+
     const showAccountAlert = await RNCallKeepModule.checkPhoneAccountPermission(options.additionalPermissions || []);
     const shouldOpenAccounts = await this._alert(options, showAccountAlert);
 


### PR DESCRIPTION
Implements support for running android in self managed mode. I've performed the implementation in a way that shouldn't change any behavior unless `selfManaged` is explicitly defined in `RNCallKeep.setup()`:

```js
 RNCallKeep.setup({
  android: {
    alertTitle: 'Permissions required',
    alertDescription: 'This application needs to access your phone accounts',
    cancelButton: 'Cancel',
    okButton: 'OK',
    imageName: 'iconmask',
    selfManaged: true, // <- Enables self managed mode
    additionalPermissions: [],
  },
});
```

I've purposely not added any changes to the documentation yet - I feel like it would be better to do so after we've decided on if we're going to take this PR.

**Reviewing and Testing this PR**
It is anything but trivial to provide an example app for this, but I recommend performing these tests:
1. Verify that all functionality works as expected when `selfManaged` is NOT enabled.
2. In `selfManaged` mode, verify that `showIncomingCallUi` is fired in response to `RNCallKeep.displayIncomingCall`

The essence of this feature is just to make RNCallKeep deliver the `showIncomingCallUi` event to react native.

**A summary of changes**

1. Added `showIncomingCallUi` do the device emitter. This event is fired when the `onShowIncomingCall()` ([link](https://developer.android.com/reference/android/telecom/Connection#onShowIncomingCallUi())) method is called by android on the Connection implementation.
2. Adjust which permissions are required in `RNCallKeepModule.java` when running in `selfManaged` mode.
3. Changed `index.js` so it doesn't open phone accounts if running in `selfManaged` mode.
4. Added `showIncomingCallUi` event to `index.d.ts`

![684d065f-d09e-4ebb-aa92-1e1a7d15d590](https://user-images.githubusercontent.com/11507553/113859556-523c1780-97a5-11eb-80b3-66fa6b4c99d4.png)

**Marked in yellow in this diagram**, is the only difference in operating principle of this module when running in self managed mode. At that point, responsibility of handling the UI related to the call falls entirely on the implementing app.

The app must still call all the relevant RNCK methods, and listen to the relevant events (such as end call, hold call etc.).

On an incoming call, we eventually execute `RNCallKeep.displayIncomingCall(callUuid, callerNumber, callerName);` - in turn, if Android deems this appropriate, it'll fire the `showIncomingCallUi` event, at which point we need code that shows a notification.

Anyway, let's discuss this wonderful feature!

**Opinion piece on how this should be implemented:**
I can see from the other PR that was made for a feature - implementation is fairly similar to this one, that there's always talk about weather this works in background state, with the app dead, foreground etc, and I'd like to address some of that.

Firstly, there are my personal opinions, so we should of course talk about what we recommend for people implementing this.

But one prevailing fact remains, and that is that every app has individual implementation quirks around the sip stack, how it's implemented, what their infrastructure is capable of and all that - all of which means that this feature shouldn't be opinionated in nature.

Battling with stuff like background state, race conditions with initialization of the React Native bridge and so on, are all symptoms of a poor fit into an existing app and it's quirks.

Now on IOS, because of Apple's requirements to show the ring screen within (2?) seconds, all implementations should converge on doing everything in `AppDelegate.m` (see my other pull request on that).

However, on Android we're not as restricted (yet), but we should be prepared for that, and as such not impose a ton of opinion on the implementors.

But a requirements that FCM does have is that any high priority notification should result in a high priority notification, or they might deprioritize your messages. As such ANY high priority message should, no matter what, invoke `RNCallKeep.displayIncomingCall(callUuid, callerNumber, callerName);` asap - before even attempting to establish a SIP connection, and then deal with synchronizing this after the fact. And this is the part that'll be extremely different between apps.

My personal recommandation for implementation, is that people have their own implementation of firebase, that'll immediately launch a headless task in react native, that'll immediately invoke `RNCallKeep.displayIncomingCall(callUuid, callerNumber, callerName);` - and then start setting up the SIP connection, and converge these based on how the user interacts with the notification that's shown.

One important thing to know, is that the full screen notification can be done fully in react native - all of which will require some interaction with native android through the native bridge.

The headless tasks starts incredibly fast, and ensures that we launch the notification fast.

Libraries like `react-native-notifications` are unfortunately NOT appropriate for use together with these. They're a recipe for a poor implementation that'll make your apps ability to receive phone calls unreliable. They're too opinionated and hides away too much functionality.

Even on Android, doing something like this WILL require a fair amount of native implementation to achieve any degree of success. It simply won't work to operate only in React Native land for this.

A good example of what we're dealing with in other notification libraries, is that they all rely on an event handler to receive device tokens - and googles documentation is extremely clear on the fact that they can distribute a new device token at any point in time. A headless task is the only appropriate way to transport a device token to react native. Event handlers are NOT.

The immediate example that comes to mind is that Google distributes a new push token while the app is not running - there is no event bridge running, and no new token is stored. A headless task allows native to wake up enough of the react native app to deal with this.