### PR TITLE
Native callback for call rejects

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ Self Managed calling apps are an advanced topic, and there are many steps involv
 
 ## Methods
 
+### getInitialEvents
+
+if there were some actions performed by user before JS context has been created, this method would return early fired events. This is alternative to "didLoadWithEvents" handler.
+
+iOS only.
+
+```js
+RNCallKeep.getInitialEvents();
+```
+
 ### setAvailable
 _This feature is available only on Android._
 

--- a/index.js
+++ b/index.js
@@ -326,6 +326,13 @@ class RNCallKeep {
 
     NativeModules.RNCallKeep.backToForeground();
   }
+
+  getInitialEvents() {
+    if (isIOS) {
+      return RNCallKeepModule.getInitialEvents()
+    }
+    return Promise.resolve([])
+  }
 }
 
 export default new RNCallKeep();

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -45,6 +45,8 @@ continueUserActivity:(NSUserActivity *)userActivity
 
 + (BOOL)isCallActive:(NSString *)uuidString;
 
-+ (void)setup:(NSDictionary *)options withEventHandler: (void (^) (NSString * eventName, id data)) onEvent;
++ (void)setup:(NSDictionary *)options;
+
++ (void)setup:(NSDictionary *)options callRejectHandler: (void (^) (NSString* uuid, void (^completion)(void))) onReject;
 
 @end

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -45,6 +45,6 @@ continueUserActivity:(NSUserActivity *)userActivity
 
 + (BOOL)isCallActive:(NSString *)uuidString;
 
-+ (void)setup:(NSDictionary *)options;
++ (void)setup:(NSDictionary *)options withEventHandler: (void (^) (NSString * eventName, id data)) onEvent;
 
 @end


### PR DESCRIPTION
This callback helps in cases when JS context is not loaded and call rejection have to be instantly reported to backend