### PR TITLE
Implement Android Connection.onSilence() event

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ The following values will match those initially passed to `displayIncomingCall`
 
 Android only. Self Managed only.
 
-Corresponds to the native [onSilence event](https://developer.android.com/reference/android/telecom/Connection#onSilence()). 
+Corresponds to the native [onSilence event](https://developer.android.com/reference/android/telecom/Connection#onSilence()). The implementor should silence the corresponding incoming calls notification sound when and if this event is fired.
 
 ```js
 RNCallKeep.addEventListener('silenceIncomingCall', ({ handle, callUUID, name }) => {

--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ RNCallKeep.addEventListener('didLoadWithEvents', (events) => {
 
 ### - showIncomingCallUi
 
-Android only.
+Android only. Self Managed only.
 
 Only when CallKeep is setup to be in self managed mode. Signals that the app must show an incoming call UI. The implementor must either call `displayIncomingCall` from react native or native android code to make this event fire.
 
@@ -738,6 +738,28 @@ The following values will match those initially passed to `displayIncomingCall`
   - The UUID of the call.
 - `name` (string)
   - Caller Name.
+
+### - silenceIncomingCall
+
+Android only. Self Managed only.
+
+Corresponds to the native [onSilence event](https://developer.android.com/reference/android/telecom/Connection#onSilence()). 
+
+```js
+RNCallKeep.addEventListener('silenceIncomingCall', ({ handle, callUUID, name }) => {
+
+});
+```
+
+The following values will match those initially passed to `silenceIncomingCall`
+
+- `handle` (string)
+  - Phone number of the incoming caller.
+- `callUUID` (string)
+  - The UUID of the call.
+- `name` (string)
+  - Caller Name.
+
 
 ### - checkReachability
 

--- a/actions.js
+++ b/actions.js
@@ -16,6 +16,7 @@ const RNCallKeepProviderReset = 'RNCallKeepProviderReset';
 const RNCallKeepCheckReachability = 'RNCallKeepCheckReachability';
 const RNCallKeepDidLoadWithEvents = 'RNCallKeepDidLoadWithEvents';
 const RNCallKeepShowIncomingCallUi = 'RNCallKeepShowIncomingCallUi';
+const RNCallKeepOnSilenceIncomingCall = 'RNCallKeepOnSilenceIncomingCall';
 const isIOS = Platform.OS === 'ios';
 
 const didReceiveStartCallAction = handler => {
@@ -63,6 +64,9 @@ const didLoadWithEvents = handler =>
 const showIncomingCallUi = handler =>
   eventEmitter.addListener(RNCallKeepShowIncomingCallUi, (data) => handler(data));
 
+const silenceIncomingCall = handler =>
+  eventEmitter.addListener(RNCallKeepOnSilenceIncomingCall, (data) => handler(data));
+
 export const emit = (eventName, payload) => eventEmitter.emit(eventName, payload);
 
 export const listeners = {
@@ -78,5 +82,6 @@ export const listeners = {
   didResetProvider,
   checkReachability,
   didLoadWithEvents,
-  showIncomingCallUi
+  showIncomingCallUi,
+  silenceIncomingCall
 };

--- a/android/src/main/java/io/wazo/callkeep/Constants.java
+++ b/android/src/main/java/io/wazo/callkeep/Constants.java
@@ -13,6 +13,8 @@ public class Constants {
     public static final String ACTION_UNMUTE_CALL = "ACTION_UNMUTE_CALL";
     public static final String ACTION_WAKE_APP = "ACTION_WAKE_APP";
     public static final String ACTION_SHOW_INCOMING_CALL_UI = "ACTION_SHOW_INCOMING_CALL_UI";
+    public static final String ACTION_ON_SILENCE_INCOMING_CALL = "ACTION_ON_SILENCE_INCOMING_CALL";
+
 
     public static final String EXTRA_CALL_NUMBER = "EXTRA_CALL_NUMBER";
     public static final String EXTRA_CALL_NUMBER_SCHEMA = "EXTRA_CALL_NUMBER_SCHEMA";

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -86,6 +86,7 @@ import static io.wazo.callkeep.Constants.ACTION_AUDIO_SESSION;
 import static io.wazo.callkeep.Constants.ACTION_CHECK_REACHABILITY;
 import static io.wazo.callkeep.Constants.ACTION_WAKE_APP;
 import static io.wazo.callkeep.Constants.ACTION_SHOW_INCOMING_CALL_UI;
+import static io.wazo.callkeep.Constants.ACTION_ON_SILENCE_INCOMING_CALL;
 
 // @see https://github.com/kbagchiGWC/voice-quickstart-android/blob/9a2aff7fbe0d0a5ae9457b48e9ad408740dfb968/exampleConnectionService/src/main/java/com/twilio/voice/examples/connectionservice/VoiceConnectionServiceActivity.java
 public class RNCallKeepModule extends ReactContextBaseJavaModule {
@@ -726,6 +727,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
             intentFilter.addAction(ACTION_AUDIO_SESSION);
             intentFilter.addAction(ACTION_CHECK_REACHABILITY);
             intentFilter.addAction(ACTION_SHOW_INCOMING_CALL_UI);
+            intentFilter.addAction(ACTION_ON_SILENCE_INCOMING_CALL);
+
             LocalBroadcastManager.getInstance(this.reactContext).registerReceiver(voiceBroadcastReceiver, intentFilter);
             isReceiverRegistered = true;
         }
@@ -817,6 +820,12 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
                     if (name != null) {
                         HeadlessJsTaskService.acquireWakeLockNow(reactContext);
                     }
+                    break;
+                case ACTION_ON_SILENCE_INCOMING_CALL:
+                    args.putString("handle", attributeMap.get(EXTRA_CALL_NUMBER));
+                    args.putString("callUUID", attributeMap.get(EXTRA_CALL_UUID));
+                    args.putString("name", attributeMap.get(EXTRA_CALLER_NAME));
+                    sendEventToJS("RNCallKeepOnSilenceIncomingCall", args);
                     break;
             }
         }

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -49,6 +49,7 @@ import static io.wazo.callkeep.Constants.EXTRA_CALLER_NAME;
 import static io.wazo.callkeep.Constants.EXTRA_CALL_NUMBER;
 import static io.wazo.callkeep.Constants.EXTRA_CALL_UUID;
 import static io.wazo.callkeep.Constants.ACTION_SHOW_INCOMING_CALL_UI;
+import static io.wazo.callkeep.Constants.ACTION_ON_SILENCE_INCOMING_CALL;
 
 @TargetApi(Build.VERSION_CODES.M)
 public class VoiceConnection extends Connection {
@@ -269,6 +270,7 @@ public class VoiceConnection extends Connection {
     public void onSilence() {
         super.onSilence();
 
+        sendCallRequestToActivity(ACTION_ON_SILENCE_INCOMING_CALL, handle);
         Log.d(TAG, "[VoiceConnection] onSilence called");
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,8 @@ declare module 'react-native-callkeep' {
     'checkReachability' |
     'didPerformSetMutedCallAction' |
     'didLoadWithEvents' |
-    'showIncomingCallUi';
+    'showIncomingCallUi' |
+    'silenceIncomingCall';
 
   type HandleType = 'generic' | 'number' | 'email';
 


### PR DESCRIPTION
Added the https://developer.android.com/reference/android/telecom/Connection#onSilence() event. Needed to support muting an incoming call notification on Android 10 and below. Android 11 seems to do this on it's own without implementing this explicitly.