### PR TITLE
Allow to display incoming call natively on Android

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -40,8 +40,17 @@ const didActivateAudioSession = handler =>
 const didDeactivateAudioSession = handler =>
   eventEmitter.addListener(RNCallKeepDidDeactivateAudioSession, handler);
 
-const didDisplayIncomingCall = handler =>
-  eventEmitter.addListener(RNCallKeepDidDisplayIncomingCall, (data) => handler(data));
+const didDisplayIncomingCall = handler => eventEmitter.addListener(RNCallKeepDidDisplayIncomingCall, data => {
+  // On Android the payload parameter is sent a String
+  // As it requires too much code on Android to convert it to WritableMap, let's do it here.
+  if (data.payload && typeof data.payload === 'string') {
+    try {
+      data.payload = JSON.parse(data.payload);
+    } catch (_) {
+    }
+  }
+  handler(data);
+});
 
 const didPerformSetMutedCallAction = handler =>
   eventEmitter.addListener(RNCallKeepDidPerformSetMutedCallAction, (data) => handler(data));

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -57,6 +57,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 import com.facebook.react.modules.permissions.PermissionsModule;
@@ -93,6 +94,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     public static final int REQUEST_READ_PHONE_STATE = 1337;
     public static final int REQUEST_REGISTER_CALL_PROVIDER = 394859;
 
+    public static RNCallKeepModule instance = null;
+
     private static final String E_ACTIVITY_DOES_NOT_EXIST = "E_ACTIVITY_DOES_NOT_EXIST";
     private static final String REACT_NATIVE_MODULE_NAME = "RNCallKeep";
     private static String[] permissions = {
@@ -110,21 +113,70 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     private boolean isReceiverRegistered = false;
     private VoiceBroadcastReceiver voiceBroadcastReceiver;
     private ReadableMap _settings;
+    private WritableNativeArray delayedEvents;
+    private boolean hasListeners = false;
 
-    public RNCallKeepModule(ReactApplicationContext reactContext) {
+    public static RNCallKeepModule getInstance(ReactApplicationContext reactContext, boolean realContext) {
+        if (instance == null) {
+            instance = new RNCallKeepModule(reactContext);
+        }
+        if (realContext) {
+            instance.setContext(reactContext);
+        }
+        return instance;
+    }
+
+    private RNCallKeepModule(ReactApplicationContext reactContext) {
         super(reactContext);
         Log.d(TAG, "[VoiceConnection] constructor");
 
         this.reactContext = reactContext;
-    }
-
-    private boolean isSelfManaged() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && _settings.hasKey("selfManaged") && _settings.getBoolean("selfManaged");
+        delayedEvents = new WritableNativeArray();
+        this.registerReceiver();
     }
 
     @Override
     public String getName() {
         return REACT_NATIVE_MODULE_NAME;
+    }
+
+    public void setContext(ReactApplicationContext reactContext) {
+        Log.d(TAG, "[VoiceConnection] updating react context");
+        this.reactContext = reactContext;
+    }
+
+    public void reportNewIncomingCall(String uuid, String number, String callerName, boolean hasVideo, String payload) {
+        Log.d(TAG, "[VoiceConnection] reportNewIncomingCall, uuid: " + uuid + ", number: " + number + ", callerName: " + callerName);
+        // @TODO: handle video
+
+        this.displayIncomingCall(uuid, number, callerName);
+
+        // Send event to JS
+        WritableMap args = Arguments.createMap();
+        args.putString("handle", number);
+        args.putString("callUUID", uuid);
+        args.putString("name", callerName);
+        if (payload != null) {
+            args.putString("payload", payload);
+        }
+        sendEventToJS("RNCallKeepDidDisplayIncomingCall", args);
+    }
+
+    public void startObserving() {
+        int count = delayedEvents.size();
+        Log.d(TAG, "[VoiceConnection] startObserving, event count: " + count);
+        if (count > 0) {
+            this.reactContext.getJSModule(RCTDeviceEventEmitter.class).emit("RNCallKeepDidLoadWithEvents", delayedEvents);
+        }
+    }
+
+    public void initializeTelecomManager() {
+        Context context = this.getAppContext();
+        ComponentName cName = new ComponentName(context, VoiceConnectionService.class);
+        String appName = this.getApplicationName(context);
+
+        handle = new PhoneAccountHandle(cName, appName);
+        telecomManager = (TelecomManager) context.getSystemService(Context.TELECOM_SERVICE);
     }
 
     @ReactMethod
@@ -152,6 +204,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         if (isConnectionServiceAvailable()) {
             this.registerPhoneAccount();
             this.registerEvents();
+            this.startObserving();
             VoiceConnectionService.setAvailable(true);
         }
 
@@ -179,8 +232,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
         Log.d(TAG, "[VoiceConnection] registerEvents");
 
-        voiceBroadcastReceiver = new VoiceBroadcastReceiver();
-        registerReceiver();
+        this.hasListeners = true;
+        this.startObserving();
         VoiceConnectionService.setPhoneAccountHandle(handle);
     }
 
@@ -400,6 +453,11 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         boolean hasDefaultAccount = telecomManager.getDefaultOutgoingPhoneAccount("tel") != null;
 
         promise.resolve(!hasSim || hasDefaultAccount);
+    }
+
+    @ReactMethod
+    public void getInitialEvents(Promise promise) {
+        promise.resolve(delayedEvents);
     }
 
     @ReactMethod
@@ -639,13 +697,21 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         }
     }
 
-    private void initializeTelecomManager() {
-        Context context = this.getAppContext();
-        ComponentName cName = new ComponentName(context, VoiceConnectionService.class);
-        String appName = this.getApplicationName(context);
+    public static void onRequestPermissionsResult(int requestCode, String[] grantedPermissions, int[] grantResults) {
+        int permissionsIndex = 0;
+        List<String> permsList = Arrays.asList(permissions);
+        for (int result : grantResults) {
+            if (permsList.contains(grantedPermissions[permissionsIndex]) && result != PackageManager.PERMISSION_GRANTED) {
+                hasPhoneAccountPromise.resolve(false);
+                return;
+            }
+            permissionsIndex++;
+        }
+        hasPhoneAccountPromise.resolve(true);
+    }
 
-        handle = new PhoneAccountHandle(cName, appName);
-        telecomManager = (TelecomManager) context.getSystemService(Context.TELECOM_SERVICE);
+    private boolean isSelfManaged() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && _settings.hasKey("selfManaged") && _settings.getBoolean("selfManaged");
     }
 
     private void registerPhoneAccount(Context appContext) {
@@ -679,8 +745,15 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     private void sendEventToJS(String eventName, @Nullable WritableMap params) {
-        Log.v(TAG, "[VoiceConnection] sendEventToJS, eventName :" + eventName + ", args : " + (params != null ? params.toString() : "null"));
-        this.reactContext.getJSModule(RCTDeviceEventEmitter.class).emit(eventName, params);
+        boolean isBoundToJS = this.reactContext.hasActiveCatalystInstance();
+        Log.v(TAG, "[VoiceConnection] sendEventToJS, eventName :" + eventName + ", bound: " + isBoundToJS + ", hasListeners: " + hasListeners + " args : " + (params != null ? params.toString() : "null"));
+
+        if (isBoundToJS && hasListeners) {
+            this.reactContext.getJSModule(RCTDeviceEventEmitter.class).emit(eventName, params);
+        } else {
+            params.putString("name", eventName);
+            delayedEvents.pushMap(params);
+        }
     }
 
     private String getApplicationName(Context appContext) {
@@ -715,6 +788,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     private void registerReceiver() {
         if (!isReceiverRegistered) {
+            voiceBroadcastReceiver = new VoiceBroadcastReceiver();
             IntentFilter intentFilter = new IntentFilter();
             intentFilter.addAction(ACTION_END_CALL);
             intentFilter.addAction(ACTION_ANSWER_CALL);
@@ -736,19 +810,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     private Context getAppContext() {
         return this.reactContext.getApplicationContext();
-    }
-
-    public static void onRequestPermissionsResult(int requestCode, String[] grantedPermissions, int[] grantResults) {
-        int permissionsIndex = 0;
-        List<String> permsList = Arrays.asList(permissions);
-        for (int result : grantResults) {
-            if (permsList.contains(grantedPermissions[permissionsIndex]) && result != PackageManager.PERMISSION_GRANTED) {
-                hasPhoneAccountPromise.resolve(false);
-                return;
-            }
-            permissionsIndex++;
-        }
-        hasPhoneAccountPromise.resolve(true);
     }
 
     private class VoiceBroadcastReceiver extends BroadcastReceiver {

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepPackage.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepPackage.java
@@ -30,7 +30,7 @@ public class RNCallKeepPackage implements ReactPackage {
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Collections.<NativeModule>singletonList(new RNCallKeepModule(reactContext));
+        return Collections.<NativeModule>singletonList(RNCallKeepModule.getInstance(reactContext, true));
     }
 
     // Deprecated RN 0.47


### PR DESCRIPTION
We should be able to display a call natively on Android like on iOS with:

Adding a receiver for the push notification in your `AndroidManifest.xml` :
⚠️ Don't forget to update the `android:name` value depnding on your package name in the `receiver` section added in the `AndroidManifest.xml` file.

```
<application>
  // ...
  <receiver
    android:name="com.wazo.notification.NotificationReceiver"
    android:enabled="true"
    android:permission="android.permission.RECEIVE_BOOT_COMPLETED"
  >
    <intent-filter>
      <action android:name="com.google.android.c2dm.intent.RECEIVE" />
      <category android:name="android.intent.category.DEFAULT" />
    </intent-filter>
  </receiver>
  // ...
</application>
```

Adding this `NotificationReceiver.java` file in your package ( ):
```
package com.wazo.notification;

import android.content.BroadcastReceiver;
import android.content.Context;
import android.content.Intent;
import android.util.Log;
import android.os.Bundle;
import org.json.JSONObject;
import org.json.JSONException;
import java.util.UUID;

import io.wazo.callkeep.RNCallKeepModule;

import com.facebook.react.bridge.ReactApplicationContext;

public class NotificationReceiver extends BroadcastReceiver {
    private static final String TAG = "NotificationReceiver";

    @Override
    public void onReceive(Context context, Intent intent) {
        Bundle bundle = intent.getExtras();
        String notificationType = bundle.getString("notification_type");
        Log.d(TAG, "Received notification : " + notificationType);
        if (!notificationType.equals("incomingCall")) {
            return;
        }

        String payload = bundle.getString("items");

        try {
            JSONObject items = new JSONObject(payload);
            String callerName = items.getString("peer_caller_id_name");
            String callerNumber = items.getString("peer_caller_id_number");
            boolean hasVideo = items.getBoolean("video");
            String uuid = UUID.randomUUID().toString();

            Log.d(TAG, "Displaying a native call directly from push, uuid : " + uuid + ", number :" + callerNumber);

            RNCallKeepModule callkeep = RNCallKeepModule.getInstance(new ReactApplicationContext(context), false);
            callkeep.initializeTelecomManager();
            callkeep.reportNewIncomingCall(uuid, callerNumber, callerName, hasVideo, payload);
        } catch (JSONException e) {
            Log.e(TAG, "Unable to parse notification payload : " + payload);
        }
    }
}
```