### PR TITLE
Fix registerPhoneAccount method when manually registering Android phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ _This feature is available only on Android._
 _On iOS you still have to call `setup()`._
 
 ```js
-RNCallKeep.registerPhoneAccount();
+RNCallKeep.registerPhoneAccount(options);
 ```
 
 ### registerAndroidEvents

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -150,7 +150,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         }
 
         if (isConnectionServiceAvailable()) {
-            this.registerPhoneAccount();
+            this.registerPhoneAccount(options);
             this.registerEvents();
             VoiceConnectionService.setAvailable(true);
         }
@@ -159,7 +159,9 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void registerPhoneAccount() {
+    public void registerPhoneAccount(ReadableMap options) {
+        this._settings = options;
+
         if (!isConnectionServiceAvailable()) {
             Log.w(TAG, "[VoiceConnection] registerPhoneAccount ignored due to no ConnectionService");
             return;

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ declare module 'react-native-callkeep' {
 
     static answerIncomingCall(uuid: string): void
 
-    static registerPhoneAccount(): void
+    static registerPhoneAccount(options: IOptions): void
 
     static registerAndroidEvents(): void
 

--- a/index.js
+++ b/index.js
@@ -48,11 +48,11 @@ class RNCallKeep {
     return this._setupIOS(options.ios);
   };
 
-  registerPhoneAccount = () => {
+  registerPhoneAccount = (options) => {
     if (isIOS) {
       return;
     }
-    RNCallKeepModule.registerPhoneAccount();
+    RNCallKeepModule.registerPhoneAccount(options.android);
   };
 
   registerAndroidEvents = () => {


### PR DESCRIPTION
Hi,

[Here](https://github.com/react-native-webrtc/react-native-callkeep#registerphoneaccount) the documentation says:

> Registers Android phone account manually, useful for custom permission prompts when you don't want to call setup(). This method is called by setup, if you already use setup you don't need it.

This is currently broken because `registerPhoneAccount` is checking the `selfManaged` option that can only be defined with `setup`.

You need to pass the options to `registerPhoneAccount` (the same way you are passing the options to `setup`) in order to register Android phone manually.