### PR TITLE
Fix/compilation errors

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -202,14 +202,6 @@ public class VoiceConnection extends Connection {
     }
 
     @Override
-    public void onReject(int rejectReason) {
-        super.onReject(rejectReason);
-        Log.d(TAG, "[VoiceConnection] onReject(int) executed");
-
-        this._onReject(rejectReason, null);
-    }
-
-    @Override
     public void onReject(String replyMessage) {
         super.onReject(replyMessage);
         Log.d(TAG, "[VoiceConnection] onReject(String) executed");

--- a/index.d.ts
+++ b/index.d.ts
@@ -138,7 +138,7 @@ declare module 'react-native-callkeep' {
 
     static getCalls(): Promise<object>
 
-    static getAudioRoutes(): Promise<void>
+    static getAudioRoutes(): Promise<AudioRoute[]>
 
     static setAudioRoute: (uuid:string, inputName: string) => Promise<void>
 


### PR DESCRIPTION
Hi! Thanks to all of the maintainers and contributors of this great package! 
Currently, the master branch is not compilable for the android platform. This PR solves compilation issues and correct typings of [Switch audio devices](https://github.com/react-native-webrtc/react-native-callkeep/pull/462) feature.

Summary:
*  Fix: remove `VoiceConnection#onReject(int rejectReason)` which seems obsolete
*  Fix: correct signature of 'RNCallKeep.getAudioRoutes' method