### PR TITLE
Added missing semicolons

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -505,24 +505,24 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
                 return;
             }
             if(audioRoute.equals("Bluetooth")) {
-                Log.d(TAG,"[VoiceConnection] setting audio route: Bluetooth")
+                Log.d(TAG,"[VoiceConnection] setting audio route: Bluetooth");
                 conn.setAudioRoute(CallAudioState.ROUTE_BLUETOOTH);
                 promise.resolve(true);
                 return;
             }
             if(audioRoute.equals("Headset")) {
-                Log.d(TAG,"[VoiceConnection] setting audio route: Headset")
+                Log.d(TAG,"[VoiceConnection] setting audio route: Headset");
                 conn.setAudioRoute(CallAudioState.ROUTE_WIRED_HEADSET);
                 promise.resolve(true);
                 return;
             }
             if(audioRoute.equals("Speaker")) {
-                Log.d(TAG,"[VoiceConnection] setting audio route: Speaker")
+                Log.d(TAG,"[VoiceConnection] setting audio route: Speaker");
                 conn.setAudioRoute(CallAudioState.ROUTE_SPEAKER);
                 promise.resolve(true);
                 return;
             }
-            Log.d(TAG,"[VoiceConnection] setting audio route: Wired/Earpiece")
+            Log.d(TAG,"[VoiceConnection] setting audio route: Wired/Earpiece");
             conn.setAudioRoute(CallAudioState.ROUTE_WIRED_OR_EARPIECE);
             promise.resolve(true);
         } catch (Exception e) {


### PR DESCRIPTION
The following java file had missing semicolons, thus producing the error -->

```
error Failed to install the app. Make sure you have the Android development environment set up: https://reactnative.dev/docs/environment-setup.
Error: Command failed: gradlew.bat app:installDebug -PreactNativeDevServerPort=8081
D:\TestCheck\react-native-callkeep\android\src\main\java\io\wazo\callkeep\RNCallKeepModule.java:508: error: ';' expected
                Log.d(TAG,"[VoiceConnection] setting audio route: Bluetooth")
                                                                             ^
D:\TestCheck\react-native-callkeep\android\src\main\java\io\wazo\callkeep\RNCallKeepModule.java:514: error: ';' expected
                Log.d(TAG,"[VoiceConnection] setting audio route: Headset")
                                                                           ^
D:\TestCheck\react-native-callkeep\android\src\main\java\io\wazo\callkeep\RNCallKeepModule.java:520: error: ';' expected
                Log.d(TAG,"[VoiceConnection] setting audio route: Speaker")
                                                                           ^
D:\TestCheck\react-native-callkeep\android\src\main\java\io\wazo\callkeep\RNCallKeepModule.java:525: error: ';' expected
            Log.d(TAG,"[VoiceConnection] setting audio route: Wired/Earpiece")
```

