### PR TITLE
Fix: Setup and Permission Issue (Android)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,4 +32,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
+
 }

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -678,6 +678,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         }
 
         Intent intent = new Intent(TelecomManager.ACTION_CHANGE_PHONE_ACCOUNTS);
+        intent.setComponent(new ComponentName("com.android.server.telecom","com.android.server.telecom.settings.EnableAccountPreferenceActivity"));
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
         this.getAppContext().startActivity(intent);
     }


### PR DESCRIPTION
**--> Initial setup of the app produces the following error**
```
Could not invoke RNCallKeep.setup
null
Failed resolution of: Landroidx/ localbroadcastmanager/content/ LocalBroadcastManager;
Didn't find class "androidx.localbroadcast manager.content.Local BroadcastManager" on path: DexPathList[[zip file "/data/app/ com.myapp-NqGe6E0jHA3YTYYSdQcZqQ==/ base.apk"],nativeLibrary Directories=[/data/app/ com.myapp-NqGe6E0jHA3YTYYSdQcZqQ==/ lib/arm64, /data/app/
com.myapp-NqGe6E0jHA3YTYYSdQcZqQ==/ base.apk!/lib/arm64-v8a, /system/lib64, /system/ product/lib64]]
```

Added  (implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0') in build.gradle file.

**-- >  Device - OnePlus Nord (API level 30) Calling Phone Accounts setting**
On setup of the app, the Intent calls the wrong activity after asking for permissions. 

<img src="https://user-images.githubusercontent.com/46490809/132250435-b790f3b7-c132-413d-9f19-f04ea65e7f28.jpg"
height=200 width=100 />

Similar issue with other OnePlus device (OnePlus 6) due to implicit intent call. Added component name in the intent to call the appropriate phone accounts activity.

<img src = "https://user-images.githubusercontent.com/46490809/132250423-c052a613-2c0d-4f6d-b0f2-5c0dfe9e9b55.jpg" 
height=200 width=100 />



