### PR TITLE
Store Android settings

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/MapUtils.java
+++ b/android/src/main/java/io/wazo/callkeep/MapUtils.java
@@ -1,0 +1,76 @@
+package io.wazo.callkeep;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+
+import org.json.JSONObject;
+import org.json.JSONException;
+
+public class MapUtils {
+    // @see https://gist.github.com/viperwarp/2beb6bbefcc268dee7ad
+    public static WritableMap convertJsonToMap(JSONObject jsonObject) throws JSONException {
+        WritableMap map = new WritableNativeMap();
+
+        Iterator<String> iterator = jsonObject.keys();
+        while (iterator.hasNext()) {
+            String key = iterator.next();
+            Object value = jsonObject.get(key);
+            if (value instanceof JSONObject) {
+                map.putMap(key, convertJsonToMap((JSONObject) value));
+            } else if (value instanceof  Boolean) {
+                map.putBoolean(key, (Boolean) value);
+            } else if (value instanceof  Integer) {
+                map.putInt(key, (Integer) value);
+            } else if (value instanceof  Double) {
+                map.putDouble(key, (Double) value);
+            } else if (value instanceof String)  {
+                map.putString(key, (String) value);
+            } else {
+                map.putString(key, value.toString());
+            }
+        }
+        return map;
+    }
+
+    public static JSONObject convertMapToJson(ReadableMap readableMap) throws JSONException {
+        JSONObject object = new JSONObject();
+        ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
+        while (iterator.hasNextKey()) {
+            String key = iterator.nextKey();
+            switch (readableMap.getType(key)) {
+                case Null:
+                    object.put(key, JSONObject.NULL);
+                    break;
+                case Boolean:
+                    object.put(key, readableMap.getBoolean(key));
+                    break;
+                case Number:
+                    object.put(key, readableMap.getDouble(key));
+                    break;
+                case String:
+                    object.put(key, readableMap.getString(key));
+                    break;
+                case Map:
+                    object.put(key, convertMapToJson(readableMap.getMap(key)));
+                    break;
+            }
+        }
+        return object;
+    }
+
+    public static WritableMap readableToWritableMap(ReadableMap readableMap) {
+        try {
+            JSONObject json = convertMapToJson(readableMap);
+
+            return convertJsonToMap(json);
+        } catch (JSONException e) {
+        }
+
+        return null;
+    }
+}

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -58,12 +58,10 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
-
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 import com.facebook.react.modules.permissions.PermissionsModule;
@@ -72,7 +70,6 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -227,7 +224,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     public void setup(ReadableMap options) {
         Log.d(TAG, "[VoiceConnection] setup");
 
-        Activity activity = getCurrentActivity();
         VoiceConnectionService.setAvailable(false);
         VoiceConnectionService.setInitialized(true);
         this.setSettings(options);
@@ -285,7 +281,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void unregisterEvents() {
-        Log.d(TAG, "[VoiceConnection] unregisterEvents");
+        Log.d(TAG, "[RNCallKeepModule] unregisterEvents");
 
         this.hasListeners = false;
     }
@@ -730,9 +726,11 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         if (foregroundServerSettings == null) {
             return;
         }
+
+        // Retrieve settings and set the `foregroundService` value
         WritableMap settings = getSettings();
         if (settings != null) {
-            settings.putMap("foregroundService", readableToWritableMap(foregroundServerSettings));
+            settings.putMap("foregroundService", MapUtils.readableToWritableMap(foregroundServerSettings));
         }
 
         storeSettings(settings);
@@ -946,6 +944,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         return this.reactContext.getApplicationContext();
     }
 
+    // Store all callkeep settings in JSON
     private void storeSettings(ReadableMap options) {
         Context context = getInstance(null, false).getAppContext();
         if (context == null) {
@@ -954,7 +953,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
         SharedPreferences sharedPref = context.getSharedPreferences("rn-callkeep", Context.MODE_PRIVATE);
         try {
-            JSONObject jsonObject = convertMapToJson(options);
+            JSONObject jsonObject = MapUtils.convertMapToJson(options);
             String jsonString = jsonObject.toString();
             sharedPref.edit().putString("settings", jsonString).apply();
         } catch (JSONException e) {
@@ -974,74 +973,11 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
             if (jsonString != null) {
                 JSONObject jsonObject = new JSONObject(jsonString);
 
-                _settings = convertJsonToMap(jsonObject);
+                _settings = MapUtils.convertJsonToMap(jsonObject);
             }
         } catch(JSONException e) {
         }
     }
-
-    // @see https://gist.github.com/viperwarp/2beb6bbefcc268dee7ad
-    private static WritableMap convertJsonToMap(JSONObject jsonObject) throws JSONException {
-        WritableMap map = new WritableNativeMap();
-
-        Iterator<String> iterator = jsonObject.keys();
-        while (iterator.hasNext()) {
-            String key = iterator.next();
-            Object value = jsonObject.get(key);
-            if (value instanceof JSONObject) {
-                map.putMap(key, convertJsonToMap((JSONObject) value));
-            } else if (value instanceof  Boolean) {
-                map.putBoolean(key, (Boolean) value);
-            } else if (value instanceof  Integer) {
-                map.putInt(key, (Integer) value);
-            } else if (value instanceof  Double) {
-                map.putDouble(key, (Double) value);
-            } else if (value instanceof String)  {
-                map.putString(key, (String) value);
-            } else {
-                map.putString(key, value.toString());
-            }
-        }
-        return map;
-    }
-
-    private static JSONObject convertMapToJson(ReadableMap readableMap) throws JSONException {
-        JSONObject object = new JSONObject();
-        ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
-        while (iterator.hasNextKey()) {
-            String key = iterator.nextKey();
-            switch (readableMap.getType(key)) {
-                case Null:
-                    object.put(key, JSONObject.NULL);
-                    break;
-                case Boolean:
-                    object.put(key, readableMap.getBoolean(key));
-                    break;
-                case Number:
-                    object.put(key, readableMap.getDouble(key));
-                    break;
-                case String:
-                    object.put(key, readableMap.getString(key));
-                    break;
-                case Map:
-                    object.put(key, convertMapToJson(readableMap.getMap(key)));
-                    break;
-            }
-        }
-        return object;
-    }
-
-    private static WritableMap readableToWritableMap(ReadableMap readableMap) {
-        try {
-            JSONObject json = convertMapToJson(readableMap);
-
-            return convertJsonToMap(json);
-        } catch (JSONException e) {
-        }
-
-        return null;
-    }
-
 
     private class VoiceBroadcastReceiver extends BroadcastReceiver {
         @Override

--- a/index.js
+++ b/index.js
@@ -221,9 +221,7 @@ class RNCallKeep {
       return;
     }
 
-    RNCallKeepModule.setForegroundServiceSettings({
-      foregroundService: settings,
-    });
+    RNCallKeepModule.setForegroundServiceSettings(settings);
   };
 
   canMakeMultipleCalls = (state) => {


### PR DESCRIPTION
When displaying a call directly from a push notification, `foregroundService` settings set via `setup` or `setForegroundServiceSettings` will not be present.

So the `startForegroundService` method will not be started due to a lake of information.

This PR aims to store all the settings set via `setup` or `setForegroundServiceSettings` so the `startForegroundService`  method can retrieve them.