### PR TITLE
fix native event emitter warnings

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -195,6 +195,16 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void addListener(String eventName) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
     public void setup(ReadableMap options) {
         Log.d(TAG, "[VoiceConnection] setup");
         VoiceConnectionService.setAvailable(false);


### PR DESCRIPTION
Fix for the warnings below:

```
 `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
 `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
```
Following resolution frrom [react-native-firebase](https://github.com/invertase/react-native-firebase/pull/5616/files#diff-c887076b0c80d540aed1bfbb472cc8f20516634e8e72d53014c65d690bba4fb1)