### PR TITLE
Consistent data structure, in delayedEvents.

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -893,11 +893,14 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         if (isBoundToJS && hasListeners) {
             this.reactContext.getJSModule(RCTDeviceEventEmitter.class).emit(eventName, params);
         } else {
+            WritableMap data = Arguments.createMap();
             if (params == null) {
                 params = Arguments.createMap();
             }
-            params.putString("name", eventName);
-            delayedEvents.pushMap(params);
+
+            data.putString("name", eventName);
+            data.putMap("data", params);
+            delayedEvents.pushMap(data);
         }
     }
 


### PR DESCRIPTION
Currently the ios version emits the following [structure](https://github.com/react-native-webrtc/react-native-callkeep/blob/0f04cb0d8d3c84988e2a5f3242e2df50db95343a/ios/RNCallKeep/RNCallKeep.m#L145) to 

```
{
  name: "eventname",
  data: {
    ..params
  }
}
```

While Android emits a flat structure 

```
{
  name: "eventname",
  ..params
}
```

This pull request makes the data equivalent in both versions. Adding the data property to Android.