### PR TITLE
Check permissions in hasPhoneAccount

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -982,9 +982,10 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         return hasPermissions;
     }
 
-    private static boolean hasPhoneAccount() {
-        return isConnectionServiceAvailable() && telecomManager != null
-            && telecomManager.getPhoneAccount(handle) != null && telecomManager.getPhoneAccount(handle).isEnabled();
+    private boolean hasPhoneAccount() {
+        return isConnectionServiceAvailable() && telecomManager != null &&
+            hasPermissions() && telecomManager.getPhoneAccount(handle) != null &&
+            telecomManager.getPhoneAccount(handle).isEnabled();
     }
 
     private void registerReceiver() {


### PR DESCRIPTION
Fixes crash on Samsung devices when the phone call permission is not granted.

Steps to reproduce:

1. install app
2. deny phone calls permission when asked
3. call `hasPhoneAccount`

```
Exception in native call
java.lang.SecurityException: Neither user 10284 nor current process has android.permission.READ_PHONE_NUMBERS.
	at android.os.Parcel.createExceptionOrNull(Parcel.java:2437)
	at android.os.Parcel.createException(Parcel.java:2421)
	at android.os.Parcel.readException(Parcel.java:2404)
	at android.os.Parcel.readException(Parcel.java:2346)
	at com.android.internal.telecom.ITelecomService$Stub$Proxy.getPhoneAccount(ITelecomService.java:1926)
	at android.telecom.TelecomManager.getPhoneAccount(TelecomManager.java:1483)
	at io.wazo.callkeep.RNCallKeepModule.hasPhoneAccount(RNCallKeepModule.java:962)
	at io.wazo.callkeep.RNCallKeepModule.hasPhoneAccount(RNCallKeepModule.java:747)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:188)
	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
	at java.lang.Thread.run(Thread.java:920)
Caused by: android.os.RemoteException: Remote stack trace:
	at android.app.ContextImpl.enforce(ContextImpl.java:2273)
	at android.app.ContextImpl.enforceCallingOrSelfPermission(ContextImpl.java:2301)
	at android.content.ContextWrapper.enforceCallingOrSelfPermission(ContextWrapper.java:922)
	at com.android.server.telecom.TelecomServiceImpl.canGetPhoneAccount(TelecomServiceImpl.java:2580)
	at com.android.server.telecom.TelecomServiceImpl.access$1100(TelecomServiceImpl.java:95)

```


![image](https://user-images.githubusercontent.com/3957608/160873348-d2aba587-1de1-40dc-861a-3c79c1dbf30c.png)
