### PR TITLE
[Android] Fix permission checking in the Quit state

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -965,15 +965,11 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     private Boolean hasPermissions() {
-        Activity currentActivity = this.getCurrentReactActivity();
-
-        if (currentActivity == null) {
-            return false;
-        }
+        ReactApplicationContext context = getContext();
 
         boolean hasPermissions = true;
         for (String permission : permissions) {
-            int permissionCheck = ContextCompat.checkSelfPermission(currentActivity, permission);
+            int permissionCheck = ContextCompat.checkSelfPermission(context, permission);
             if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
                 hasPermissions = false;
             }


### PR DESCRIPTION
**Problem**: 
I'm trying to `displayIncomingCall`  in the `BackgroundMessaging` (by Firebase) when the app in the Quit state (when a user has killed the application), but it doesn't work because `hasPermissions` always returns false.
`hasPermissions` returns false because `Activity` is always null in the Quit state.

**Solution**: 
Use `ReactApplicationContext` to check permissions.