### PR TITLE
[Android] Add missing break for create connection failed

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -1144,6 +1144,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
                     args.putString("callUUID", attributeMap.get(EXTRA_CALL_UUID));
                     args.putString("name", attributeMap.get(EXTRA_CALLER_NAME));
                     sendEventToJS("RNCallKeepOnIncomingConnectionFailed", args);
+                    break;
                 case ACTION_DID_CHANGE_AUDIO_ROUTE:
                     args.putString("handle", attributeMap.get(EXTRA_CALL_NUMBER));
                     args.putString("callUUID", attributeMap.get(EXTRA_CALL_UUID));


### PR DESCRIPTION
Problem:
In the `VoiceBroadcastReceiver` after receiving an  ACTION_ON_CREATE_CONNECTION_FAILED action, there is no break in the switch case which causes `sendEventToJS` to be called twice.
This causes `Error: Map already consumed`.

Solution:
Add break