### PR TITLE
iOS: destroyProvider method has added

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -47,4 +47,6 @@ continueUserActivity:(NSUserActivity *)userActivity
 
 + (void)setup:(NSDictionary *)options;
 
++ (void)destroyProvider;
+
 @end

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -187,6 +187,15 @@ RCT_EXPORT_MODULE()
     isSetupNatively = YES;
 }
 
++ (void)destroyProvider {
+    if (sharedProvider != nil) {
+        [sharedProvider invalidate];
+        sharedProvider = nil;
+    }
+
+    isSetupNatively = NO;
+}
+
 RCT_EXPORT_METHOD(setup:(NSDictionary *)options)
 {
     if (isSetupNatively) {


### PR DESCRIPTION
Hi,

This PR contains destroying provider manually in order to be able to call setup() method again to activate ringtoneSound changes.
When user picks the new ringtone over UI, the app shouldn't be killed and reopen. In fact, it should change the ringtone sound immediately. So, I added this small helper in order to achieve this functionality.