### PR TITLE
Android : adding localbroadcastmanager support (#594 Fix)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,4 +32,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
+    implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0"
 }


### PR DESCRIPTION
Fix for issue #594
Google has split the v4 library into multiple packages :

Note: Prior to Support Library revision 24.2.0, there was a single v4 support library. That library was divided into multiple modules to improve efficiency. For backwards compatibility, if you list support-v4 in your Gradle script, your app will include all of the v4 modules. However, to reduce app size, we recommend that you just list the specific modules your app needs.

https://developer.android.com/reference/android/support/v4/content/LocalBroadcastManager

hence explicitly adding androidx.localbroadcastmanager:localbroadcastmanager:1.1.0 dependency