### PR TITLE
Fix warning in the ios documentation

### DIFF
--- a/docs/ios-installation.md
+++ b/docs/ios-installation.md
@@ -96,7 +96,7 @@ Add it before the `@end` tag.
 ```diff
 + - (BOOL)application:(UIApplication *)application
 + continueUserActivity:(NSUserActivity *)userActivity
-+   restorationHandler:(void(^)(NSArray * __nullable restorableObjects))restorationHandler
++   restorationHandler:(void(^)(NSArray<id<UIUserActivityRestoring>> * __nullable restorableObjects))restorationHandler
 + {
 +   return [RNCallKeep application:application
 +            continueUserActivity:userActivity


### PR DESCRIPTION
When following the iOS installation doc, I got a warning at [this step](https://github.com/react-native-webrtc/react-native-callkeep/blob/master/docs/ios-installation.md#4-updating-appdelegatem):

```
Conflicting parameter types in implementation of 'application:continueUserActivity:restorationHandler:': 'void (^ _Nonnull __strong)(NSArray<id<UIUserActivityRestoring>> * _Nullable __strong)' vs 'void (^__strong _Nonnull)(NSArray * _Nullable __strong)'
```

I fixed by replacing `NSArray` with `NSArray<id<UIUserActivityRestoring>>`.
