### PR TITLE
fix: missing Android RECORD_AUDIO permission

### DIFF
--- a/docs/android-installation.md
+++ b/docs/android-installation.md
@@ -65,6 +65,7 @@ public class MainActivity extends ReactActivity {
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 <uses-permission android:name="android.permission.CALL_PHONE" />
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
 
 <application>
     // ...


### PR DESCRIPTION
Hello,

On Android, `RNCallKeep.setup()` reports `false` and library is not working without the `RECORD_AUDIO` permission.

The permission is present [in the example](https://github.com/react-native-webrtc/react-native-callkeep/blob/5a29880b095ec91945ee5de9b772b7c414ba31ac/example/android/app/src/main/AndroidManifest.xml#L28) but it's missing in the installation steps.