### PR TITLE
set audio mode back to normal after end call

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -392,6 +392,9 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
             Log.w(TAG, "[RNCallKeepModule] endCall ignored because no connection found, uuid: " + uuid);
             return;
         }
+        Context context = this.getAppContext();
+        AudioManager audioManager = (AudioManager) context.getSystemService(context.AUDIO_SERVICE);
+        audioManager.setMode(0);
         conn.onDisconnect();
 
         Log.d(TAG, "[RNCallKeepModule] endCall executed, uuid: " + uuid);


### PR DESCRIPTION
this fix the problem where you can't control the audio after the call is ended and it affect other applications.
had to set audio mode to normal state.

https://developer.android.com/reference/android/media/AudioManager#MODE_NORMAL