### PR TITLE
Fixes callkit speaker button out of sync

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -894,7 +894,7 @@ RCT_EXPORT_METHOD(getAudioRoutes: (RCTPromiseResolveBlock)resolve
 #endif
 
     AVAudioSession* audioSession = [AVAudioSession sharedInstance];
-    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetooth error:nil];
+    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetooth | AVAudioSessionCategoryOptionDefaultToSpeaker error:nil];
 
     [audioSession setMode:AVAudioSessionModeDefault error:nil];
 


### PR DESCRIPTION
When setting the speaker as the audio route using the [setAudioRoute](https://github.com/react-native-webrtc/react-native-callkeep#setaudioroute) method with the call ID and 'Speaker' as params, the audio route would correctly change to speaker but the button on the CallKit UI isn't updated, leading into an inconsistent state.
In this state, if the speaker button on the CallKit UI is pressed, it will display as turned on for a few seconds and then turn off automatically. 

This issue is similar to [one reported previously](https://stackoverflow.com/questions/48023629/abnormal-behavior-of-speaker-button-on-system-provided-call-screen) which was fixed in #495 but doesn't seem to solve this case.

The issue and solution were found and tested on iOS 15.4.1