### PR TITLE
Fix: speaker button on callkit

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -894,7 +894,7 @@ RCT_EXPORT_METHOD(getAudioRoutes: (RCTPromiseResolveBlock)resolve
 #endif
 
     AVAudioSession* audioSession = [AVAudioSession sharedInstance];
-    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetooth error:nil];
+    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetooth | AVAudioSessionCategoryOptionAllowBluetoothA2DP error:nil];
 
     [audioSession setMode:AVAudioSessionModeDefault error:nil];
 


### PR DESCRIPTION
The issue mentioned in [this PR](https://github.com/react-native-webrtc/react-native-callkeep/pull/495) is persisting for me and also other people who later commented on that PR. I tested on iOS 15.4.1 and it was impossible to turn the speaker on using the CallKit UI, the speaker button would light up for a few seconds and then turn off automatically no matter how many times I attempted to turn it on.

Adding `AVAudioSessionCategoryOptionAllowBluetoothA2DP` did the trick for me and now it's working as expected