### PR TITLE
Enable phone settings for OnePlus without having to use self managed

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -838,7 +838,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        if (Build.MANUFACTURER.equalsIgnoreCase("Samsung")) {
+        if (Build.MANUFACTURER.equalsIgnoreCase("Samsung") || Build.MANUFACTURER.equalsIgnoreCase("OnePlus")) {
             Intent intent = new Intent();
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
             intent.setComponent(new ComponentName("com.android.server.telecom",


### PR DESCRIPTION
Without this, OnePlus phones will redirect to a settings window which is not correct. 
This should also be tested with `Xiaomi` and `HUAWEI`.
`Build.MANUFACTURER.equalsIgnoreCase("Xiaomi") || Build.MANUFACTURER.equalsIgnoreCase("HUAWEI")` 