### PR TITLE
Avoid to call onSilence on Android API level < 29

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -271,6 +271,11 @@ public class VoiceConnection extends Connection {
 
     @Override
     public void onSilence() {
+        // onSilence was added on API level 29
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return;
+        }
+
         super.onSilence();
 
         sendCallRequestToActivity(ACTION_ON_SILENCE_INCOMING_CALL, handle);


### PR DESCRIPTION
Cf: https://developer.android.com/reference/android/telecom/Connection?hl=en#onSilence()

And: https://github.com/react-native-webrtc/react-native-callkeep/pull/537/files#diff-5bf14dd7c9519f053dd7c65d373334375a8cec00476eec049a3e25fa7d47cae4R278

Fixes #526