### PR TITLE
Do not redirect to activity if not yet existing

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -307,20 +307,23 @@ public class VoiceConnectionService extends ConnectionService {
         assert manager != null;
         manager.createNotificationChannel(chan);
 
-        Activity currentActivity = RNCallKeepModule.instance.getCurrentReactActivity();
-        Intent notificationIntent = new Intent(this, currentActivity.getClass());
-        notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-
-        final int flag =  Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
-
-        PendingIntent pendingIntent = PendingIntent.getActivity(this, NOTIFICATION_ID, notificationIntent, flag);
-
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID);
         notificationBuilder.setOngoing(true)
             .setContentTitle(foregroundSettings.getString("notificationTitle"))
-            .setContentIntent(pendingIntent)
             .setPriority(NotificationManager.IMPORTANCE_MIN)
             .setCategory(Notification.CATEGORY_SERVICE);
+
+        Activity currentActivity = RNCallKeepModule.instance.getCurrentReactActivity();
+        if (currentActivity != null) {
+            Intent notificationIntent = new Intent(this, currentActivity.getClass());
+            notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+            final int flag =  Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
+
+            PendingIntent pendingIntent = PendingIntent.getActivity(this, NOTIFICATION_ID, notificationIntent, flag);
+
+            notificationBuilder.setContentIntent(pendingIntent);
+        }
 
         if (foregroundSettings.hasKey("notificationIcon")) {
             Context context = this.getApplicationContext();


### PR DESCRIPTION
Last release `4.3.5` introduced a redirection to the app in the foreground service notification.

But in some case (when the app is killed) the app activity may not be created yet, it will result a crash :
```
Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
at io.wazo.callkeep.VoiceConnectionService.startForegroundService(VoiceConnectionService.java:311)
at io.wazo.callkeep.VoiceConnectionService.onCreateIncomingConnection(VoiceConnectionService.java:209)
```

We need to check for the activity before creating the Intent.