### PR TITLE
Send didDisplayIncomingCall event on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,8 @@ Callback for `RNCallKeep.displayIncomingCall`
 ```js
 RNCallKeep.addEventListener('didDisplayIncomingCall', ({ error, callUUID, handle, localizedCallerName, hasVideo, fromPushKit, payload }) => {
   // you might want to do following things when receiving this event:
-  // - Start playing ringback if it is an outgoing call
+  // - Navigate to your incoming call screen
+  // - Handle errors on iOS
 });
 ```
 
@@ -816,9 +817,11 @@ RNCallKeep.addEventListener('didDisplayIncomingCall', ({ error, callUUID, handle
   - `1` (video enabled)
   - `0` (video not enabled)
 - `fromPushKit` (string)
+  - iOS only.
   - `1` (call triggered from PushKit)
   - `0` (call not triggered from PushKit)
 - `payload` (object)
+  - iOS only.
   - VOIP push payload.
 
 ### didPerformSetMutedCallAction

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -181,17 +181,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         Log.d(TAG, "[RNCallKeepModule] reportNewIncomingCall, uuid: " + uuid + ", number: " + number + ", callerName: " + callerName);
 
         this.displayIncomingCall(uuid, number, callerName, hasVideo);
-
-        // Send event to JS
-        WritableMap args = Arguments.createMap();
-        args.putString("handle", number);
-        args.putString("callUUID", uuid);
-        args.putString("name", callerName);
-        args.putString("hasVideo", String.valueOf(hasVideo));
-        if (payload != null) {
-            args.putString("payload", payload);
-        }
-        sendEventToJS("RNCallKeepDidDisplayIncomingCall", args);
     }
 
     public void startObserving() {
@@ -329,6 +318,15 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
         extras.putString(EXTRA_HAS_VIDEO, String.valueOf(hasVideo));
 
         telecomManager.addNewIncomingCall(handle, extras);
+
+        // Send event to JS
+        WritableMap args = Arguments.createMap();
+        args.putString("handle", number);
+        args.putString("callUUID", uuid);
+        args.putString("localizedCallerName", callerName);
+        args.putString("hasVideo", hasVideo ? "1" : "0");
+
+        sendEventToJS("RNCallKeepDidDisplayIncomingCall", args);
     }
 
     @ReactMethod


### PR DESCRIPTION
Sends the didDisplayIncomingCall event when `RNCallKeep.displayIncomingCall` is called on Android. The documentation is also updated to reflect the which arguments are available on iOS only.

Fixes #671.