### PR TITLE
Add support for I/O connection through Car Audio on iOS

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -621,6 +621,9 @@ RCT_EXPORT_METHOD(getAudioRoutes: (RCTPromiseResolveBlock)resolve
     else if ([type isEqualToString:AVAudioSessionPortBuiltInSpeaker]){
         return @"Speaker";
     }
+    else if ([type isEqualToString:AVAudioSessionPortCarAudio]) {
+        return @"CarAudio";
+    }
     else{
         return nil;
     }


### PR DESCRIPTION
Adds [AVAudioSessionPortCarAudio](https://developer.apple.com/documentation/avfaudio/avaudiosessionportcaraudio) as a condition of `getAudioInputType` and returns it as `CarAudio`