### PR TITLE
Multiple event listener support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,6 @@ declare module 'react-native-callkeep' {
   }
 
   type HandleType = 'generic' | 'number' | 'email';
-  type EventListener = {};
 
   export type AudioRoute = {
     name: string,
@@ -127,6 +126,10 @@ declare module 'react-native-callkeep' {
     }
   };
 
+  export class EventListener {
+    remove(): void
+  }
+
   export default class RNCallKeep {
     static getInitialEvents(): Promise<InitialEvents>
 
@@ -137,12 +140,7 @@ declare module 'react-native-callkeep' {
       handler: EventHandlers[Event],
     ): EventListener
 
-    /**
-     * @description Remove specific event listener if given, otherwise remove all belonging to the given event type.
-     * @param type 
-     * @param listener 
-     */
-    static removeEventListener(type: Events, listener?: EventListener): void
+    static removeEventListener(type: Events): void
 
     static setup(options: IOptions): Promise<boolean>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,6 +75,7 @@ declare module 'react-native-callkeep' {
   }
 
   type HandleType = 'generic' | 'number' | 'email';
+  type EventListener = {};
 
   export type AudioRoute = {
     name: string,
@@ -134,9 +135,14 @@ declare module 'react-native-callkeep' {
     static addEventListener<Event extends Events>(
       type: Event,
       handler: EventHandlers[Event],
-    ): void
+    ): EventListener
 
-    static removeEventListener(type: Events): void
+    /**
+     * @description Remove specific event listener if given, otherwise remove all belonging to the given event type.
+     * @param type 
+     * @param listener 
+     */
+    static removeEventListener(type: Events, listener?: EventListener): void
 
     static setup(options: IOptions): Promise<boolean>
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,17 @@ const CONSTANTS = {
 
 export { emit, CONSTANTS };
 
+class EventListener {
+  constructor(type, listener) {
+    this._type = type;
+    this._listener = listener;
+  }
+
+  remove = () => {
+    RNCallKeep.removeEventListener(this._type, this._listener);
+  };
+}
+
 class RNCallKeep {
   constructor() {
     this._callkeepEventHandlers = new Map();
@@ -32,7 +43,7 @@ class RNCallKeep {
 
     this._callkeepEventHandlers.set(type, listenerSet);
 
-    return listener;
+    return new EventListener(type, listener);
   };
 
   removeEventListener = (type, listener = undefined) => {

--- a/index.js
+++ b/index.js
@@ -27,17 +27,32 @@ class RNCallKeep {
   addEventListener = (type, handler) => {
     const listener = listeners[type](handler);
 
-    this._callkeepEventHandlers.set(type, listener);
+    const listenerSet = this._callkeepEventHandlers.get(type) ?? new Set();
+    listenerSet.add(listener);
+
+    this._callkeepEventHandlers.set(type, listenerSet);
+
+    return listener;
   };
 
-  removeEventListener = (type) => {
-    const listener = this._callkeepEventHandlers.get(type);
-    if (!listener) {
+  removeEventListener = (type, listener = undefined) => {
+    const listenerSet = this._callkeepEventHandlers.get(type);
+    if (!listenerSet) {
       return;
     }
 
-    listener.remove();
-    this._callkeepEventHandlers.delete(type);
+    if (listener) {
+      listenerSet.delete(listener);
+      listener.remove();
+      if (listenerSet.size <= 0) {
+        this._callkeepEventHandlers.delete(type);
+      }
+    } else {
+      listenerSet.forEach((listener) => {
+        listener.remove();
+      });
+      this._callkeepEventHandlers.delete(type);
+    }
   };
 
   setup = async (options) => {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class EventListener {
   }
 
   remove = () => {
-    RNCallKeep.removeEventListener(this._type, this._listener);
+    callKeep.removeEventListener(this._type, this._listener);
   };
 }
 
@@ -375,4 +375,6 @@ class RNCallKeep {
   }
 }
 
-export default new RNCallKeep();
+const callKeep = new RNCallKeep();
+
+export default callKeep;

--- a/index.js
+++ b/index.js
@@ -20,13 +20,14 @@ const CONSTANTS = {
 export { emit, CONSTANTS };
 
 class EventListener {
-  constructor(type, listener) {
+  constructor(type, listener, callkeep) {
     this._type = type;
     this._listener = listener;
+    this._callkeep = callkeep;
   }
 
   remove = () => {
-    callKeep.removeEventListener(this._type, this._listener);
+    this._callkeep.removeEventListener(this._type, this._listener);
   };
 }
 
@@ -43,7 +44,7 @@ class RNCallKeep {
 
     this._callkeepEventHandlers.set(type, listenerSet);
 
-    return new EventListener(type, listener);
+    return new EventListener(type, listener, this);
   };
 
   removeEventListener = (type, listener = undefined) => {
@@ -375,6 +376,4 @@ class RNCallKeep {
   }
 }
 
-const callKeep = new RNCallKeep();
-
-export default callKeep;
+export default new RNCallKeep();


### PR DESCRIPTION
Problem:
- Only 1 event listener is supported which makes it difficult to use when 3rd party libraries also use react-native-callkeep
- Currently, addEventListener replaces the existing listener without removing the EventSubscription and removeEventListener only removes the latest EventSubscription

Solution:
- addEventListener will add instead of replacing existing listeners and return a listener context for the caller to remove at any time individually