### PR TITLE
Null-check instance prior to being called in fetchStoredSettings

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -1079,11 +1079,11 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     protected static void fetchStoredSettings(@Nullable Context fromContext) {
-        Context context = fromContext != null ? fromContext : instance.getAppContext();
-        if (instance == null && context == null) {
+        if (instance == null && fromContext == null) {
             Log.w(TAG, "[RNCallKeepModule][fetchStoredSettings] no instance nor fromContext.");
             return;
         }
+        Context context = fromContext != null ? fromContext : instance.getAppContext();
         _settings = new WritableNativeMap();
         if (context == null) {
             Log.w(TAG, "[RNCallKeepModule][fetchStoredSettings] no react context found.");


### PR DESCRIPTION
My crashlytics reports the below error on multiple different devices, on different versions of Android OS. 


Error:
```
NullPointerException: Attempt to invoke direct method 'android.content.Context io.wazo.callkeep.RNCallKeepModule.getAppContext()' on a null object reference
```

The code in question:
```
    protected static void fetchStoredSettings(@Nullable Context fromContext) {
        Context context = fromContext != null ? fromContext : instance.getAppContext();
        if (instance == null && context == null) {
            Log.w(TAG, "[RNCallKeepModule][fetchStoredSettings] no instance nor fromContext.");
            return;
        }
       ...
    }
```

Maybe do the null-check of `instance` prior to possibly calling the getAppContext? 

For instance: 

```
    protected static void fetchStoredSettings(@Nullable Context fromContext) {
        if (instance == null && fromContext == null) {
            Log.w(TAG, "[RNCallKeepModule][fetchStoredSettings] no instance nor fromContext.");
            return;
        }
        Context context = fromContext != null ? fromContext : instance.getAppContext();
       ...
    }
```