### PR TITLE
Add iOS setup options for overriding AVAudioSession setCategory options and setMode mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ Alternative on iOS you can perform setup in `AppDelegate.m`. Doing this allows c
     - `displayCallReachabilityTimeout`: number in ms (optional)
       If provided, starts a timeout that checks if the application is reachable and ends the call if not (Default: null)
       You'll have to call `setReachable()` as soon as your Javascript application is started.
+    - `audioSession`: object
+      - `categoryOptions`: AudioSessionCategoryOption|number (optional)
+        If provided, it will override the default AVAudioSession setCategory options.
+      - `mode`: AudioSessionMode|string (optional)
+        If provided, it will override the default AVAudioSession setMode mode.
   - `android`: object
     - `alertTitle`: string (required)
       When asking for _phone account_ permission, we need to provider a title for the `Alert` to ask the user for it

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,29 @@ declare module 'react-native-callkeep' {
     selected?: boolean
   }
 
+  export enum AudioSessionCategoryOption {
+    mixWithOthers = 0x1,
+    duckOthers = 0x2,
+    interruptSpokenAudioAndMixWithOthers = 0x11,
+    allowBluetooth = 0x4,
+    allowBluetoothA2DP = 0x20,
+    allowAirPlay = 0x40,
+    defaultToSpeaker = 0x8,
+    overrideMutedMicrophoneInterruption = 0x80,
+  }
+  
+  export enum AudioSessionMode {
+    default = 'AVAudioSessionModeDefault',
+    gameChat = 'AVAudioSessionModeGameChat',
+    measurement = 'AVAudioSessionModeMeasurement',
+    moviePlayback = 'AVAudioSessionModeMoviePlayback',
+    spokenAudio = 'AVAudioSessionModeSpokenAudio',
+    videoChat = 'AVAudioSessionModeVideoChat',
+    videoRecording = 'AVAudioSessionModeVideoRecording',
+    voiceChat = 'AVAudioSessionModeVoiceChat',
+    voicePrompt = 'AVAudioSessionModeVoicePrompt',
+  }
+
   interface IOptions {
     ios: {
       appName: string,
@@ -73,6 +96,10 @@ declare module 'react-native-callkeep' {
       maximumCallsPerCallGroup?: string,
       ringtoneSound?: string,
       includesCallsInRecents?: boolean
+      audioSession?: {
+        categoryOptions?: AudioSessionCategoryOption | number,
+        mode?: AudioSessionMode | string,
+      }
     },
     android: {
       alertTitle: string,

--- a/index.js
+++ b/index.js
@@ -6,6 +6,29 @@ const RNCallKeepModule = NativeModules.RNCallKeep;
 const isIOS = Platform.OS === 'ios';
 const supportConnectionService = !isIOS && Platform.Version >= 23;
 
+const AudioSessionCategoryOption = {
+  mixWithOthers: 0x1,
+  duckOthers: 0x2,
+  interruptSpokenAudioAndMixWithOthers: 0x11,
+  allowBluetooth: 0x4,
+  allowBluetoothA2DP: 0x20,
+  allowAirPlay: 0x40,
+  defaultToSpeaker: 0x8,
+  overrideMutedMicrophoneInterruption: 0x80,
+}
+
+const AudioSessionMode = {
+  default: 'AVAudioSessionModeDefault',
+  gameChat: 'AVAudioSessionModeGameChat',
+  measurement: 'AVAudioSessionModeMeasurement',
+  moviePlayback: 'AVAudioSessionModeMoviePlayback',
+  spokenAudio: 'AVAudioSessionModeSpokenAudio',
+  videoChat: 'AVAudioSessionModeVideoChat',
+  videoRecording: 'AVAudioSessionModeVideoRecording',
+  voiceChat: 'AVAudioSessionModeVoiceChat',
+  voicePrompt: 'AVAudioSessionModeVoicePrompt',
+}
+
 const CONSTANTS = {
   END_CALL_REASONS: {
     FAILED: 1,
@@ -17,7 +40,7 @@ const CONSTANTS = {
   },
 };
 
-export { emit, CONSTANTS };
+export { emit, CONSTANTS, AudioSessionCategoryOption, AudioSessionMode };
 
 class EventListener {
   constructor(type, listener, callkeep) {

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -896,10 +896,24 @@ RCT_EXPORT_METHOD(getAudioRoutes: (RCTPromiseResolveBlock)resolve
     NSLog(@"[RNCallKeep][configureAudioSession] Activating audio session");
 #endif
 
-    AVAudioSession* audioSession = [AVAudioSession sharedInstance];
-    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionAllowBluetooth | AVAudioSessionCategoryOptionAllowBluetoothA2DP error:nil];
+    NSUInteger categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+    NSString *mode = AVAudioSessionModeDefault;
+    
+    NSDictionary *settings = [RNCallKeep getSettings];
+    if (settings && settings[@"audioSession"]) {
+        if (settings[@"audioSession"][@"categoryOptions"]) {
+            categoryOptions = [settings[@"audioSession"][@"categoryOptions"] integerValue];
+        }
 
-    [audioSession setMode:AVAudioSessionModeDefault error:nil];
+        if (settings[@"audioSession"][@"mode"]) {
+            mode = settings[@"audioSession"][@"mode"];
+        }
+    }
+    
+    AVAudioSession* audioSession = [AVAudioSession sharedInstance];
+    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:categoryOptions error:nil];
+
+    [audioSession setMode:mode error:nil];
 
     double sampleRate = 44100.0;
     [audioSession setPreferredSampleRate:sampleRate error:nil];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-callkeep",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "description": "iOS 10 CallKit and Android ConnectionService Framework For React Native",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Currently, configureAudioSession uses fixed values for setCategory options and setMode mode.
This change will allow options to be passed into the setup function to override the default values in configureAudioSession.