### PR TITLE
Improve Logging consistency by removing double bracket

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -150,7 +150,7 @@ RCT_EXPORT_MODULE()
 }
 
 - (void)sendEventWithNameWrapper:(NSString *)name body:(id)body {
-    NSLog(@"[[RNCallKeep]] sendEventWithNameWrapper: %@, hasListeners : %@", name, _hasListeners ? @"YES": @"NO");
+    NSLog(@"[RNCallKeep] sendEventWithNameWrapper: %@, hasListeners : %@", name, _hasListeners ? @"YES": @"NO");
 
     if (_hasListeners) {
         [self sendEventWithName:name body:body];


### PR DESCRIPTION
## What changed

- No functionality should be impacted by this change
- Removed a double bracket in NSLog for a single bracket

## How did you test

- I made the change and saw it in the Console app