### PR TITLE
Multiple fixes on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Self Managed calling apps are an advanced topic, and there are many steps involv
 | [setForegroundServiceSettings()](#setForegroundServiceSettings)   | `Promise<void>`     |  ❌  |   ✅    |
 | [canMakeMultipleCalls()](#canMakeMultipleCalls)                   | `Promise<void>`     |  ❌  |   ✅    |
 | [setCurrentCallActive()](#setCurrentCallActive)                   | `Promise<void>`     |  ❌  |   ✅    |
+| [checkIsInManagedCall()](#setAvailable)                           | `Promise<Boolean>`  |  ❌  |   ✅    |
 | [isCallActive()](#isCallActive)                                   | `Promise<Boolean>`  |  ✅  |   ❌    |
 | [getCalls()](#getCalls)                                           | `Promise<Object[]>` |  ✅  |   ❌    |
 | [displayIncomingCall()](#displayIncomingCall)                     | `Promise<void>`     |  ✅  |   ✅    |
@@ -315,6 +316,16 @@ RNCallKeep.setCurrentCallActive(uuid);
 
 - `uuid`: string
   - The `uuid` used for `startCall` or `displayIncomingCall`
+
+### checkIsInManagedCall
+_This feature is available only on Android._
+
+Returns true if there is an active native call
+
+```js
+RNCallKeep.checkIsInManagedCall();
+```
+
 
 ### isCallActive
 _This feature is available only on IOS._
@@ -741,6 +752,7 @@ RNCallKeep.registerAndroidEvents();
 | [silenceIncomingCall](#silenceIncomingCall)                     |  ❌  |   ✅    |
 | [checkReachability](#checkReachability)                         |  ❌  |   ✅    |
 | [didChangeAudioRoute](#didChangeAudioRoute)                     |  ✅  |   ✅    |
+| [onHasActiveCall](#onHasActiveCall)                             |  ❌  |   ✅    |
 
 ### didReceiveStartCallAction
 
@@ -989,6 +1001,19 @@ So we have to check if the application is reachable before making a call from th
 ```js
 RNCallKeep.addEventListener('checkReachability', () => {
   RNCallKeep.setReachable();
+});
+
+```
+
+### onHasActiveCall
+
+_Android only._
+
+A listener to tells the JS side if a native call has been answered while there is active self managed call
+
+```js
+RNCallKeep.addEventListener('onHasActiveCall', () => {
+  // eg: End active app call if native call is answered
 });
 
 ```

--- a/README.md
+++ b/README.md
@@ -1009,7 +1009,7 @@ RNCallKeep.addEventListener('checkReachability', () => {
 
 _Android only._
 
-A listener to tells the JS side if a native call has been answered while there is active self managed call
+A listener that tells the JS side if a native call has been answered while there was an active self-managed call
 
 ```js
 RNCallKeep.addEventListener('onHasActiveCall', () => {

--- a/actions.js
+++ b/actions.js
@@ -19,6 +19,7 @@ const RNCallKeepShowIncomingCallUi = 'RNCallKeepShowIncomingCallUi';
 const RNCallKeepOnSilenceIncomingCall = 'RNCallKeepOnSilenceIncomingCall';
 const RNCallKeepOnIncomingConnectionFailed = 'RNCallKeepOnIncomingConnectionFailed';
 const RNCallKeepDidChangeAudioRoute = 'RNCallKeepDidChangeAudioRoute';
+const RNCallKeepHasActiveCall = 'RNCallKeepHasActiveCall';
 const isIOS = Platform.OS === 'ios';
 
 const didReceiveStartCallAction = handler => {
@@ -59,6 +60,9 @@ const didDisplayIncomingCall = handler => eventEmitter.addListener(RNCallKeepDid
 
 const didPerformSetMutedCallAction = handler =>
   eventEmitter.addListener(RNCallKeepDidPerformSetMutedCallAction, (data) => handler(data));
+
+const onHasActiveCall = handler =>
+  eventEmitter.addListener(RNCallKeepHasActiveCall, handler);
 
 const didToggleHoldCallAction = handler =>
   eventEmitter.addListener(RNCallKeepDidToggleHoldAction, handler);
@@ -103,4 +107,5 @@ export const listeners = {
   silenceIncomingCall,
   createIncomingConnectionFailed,
   didChangeAudioRoute,
+  onHasActiveCall
 };

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -236,7 +236,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
              switch (state) {
                  case TelephonyManager.CALL_STATE_RINGING:
                      // Incoming call is ringing (not used for outgoing call).
-                     Log.i("onCallStateChanged", "CALL_STATE_RINGING");
                      break;
                  case TelephonyManager.CALL_STATE_OFFHOOK:
                      // Phone call is active -- off the hook.
@@ -245,22 +244,19 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
 
                       // Only let the JS side know if there is active app call & active native call
                       if(RNCallKeepModule.this.hasActiveCall && isInManagedCall){
-                          WritableMap args = Arguments.createMap();
-                          RNCallKeepModule.this.sendEventToJS("RNCallKeepHasActiveCall",args);
+                         WritableMap args = Arguments.createMap();
+                         RNCallKeepModule.this.sendEventToJS("RNCallKeepHasActiveCall",args);
                       }else if(VoiceConnectionService.currentConnections.size() > 0){
                         // Will enter here for the first time to mark the app has active call
-                          RNCallKeepModule.this.hasActiveCall = true;
+                         RNCallKeepModule.this.hasActiveCall = true;
                       }
-                     Log.i("onCallStateChanged", "CALL_STATE_OFFHOOK");
                      break;
                  case TelephonyManager.CALL_STATE_IDLE:
                      // Phone is idle before and after phone call.
                      // If running on version older than 19 (KitKat),
                      // restart activity when phone call ends.
-                     Log.i("onCallStateChanged", "CALL_STATE_IDLE");
                      break;
                  default:
-                     Log.i("onCallStateChanged", "default");
                      break;
              }
          }
@@ -273,7 +269,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
               switch (state) {
                   case TelephonyManager.CALL_STATE_RINGING:
                       // Incoming call is ringing (not used for outgoing call).
-                      Log.i("onCallStateChanged", "CALL_STATE_RINGING");
                       break;
                   case TelephonyManager.CALL_STATE_OFFHOOK:
                       // Phone call is active -- off the hook.
@@ -289,35 +284,34 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
                         // Will enter here for the first time to mark the app has active call
                           RNCallKeepModule.this.hasActiveCall = true;
                       }
-                      Log.i("onCallStateChanged", "CALL_STATE_OFFHOOK");
                       break;
                   case TelephonyManager.CALL_STATE_IDLE:
                       // Phone is idle before and after phone call.
                       // If running on version older than 19 (KitKat),
                       // restart activity when phone call ends.
-                      Log.i("onCallStateChanged", "CALL_STATE_IDLE");
                       break;
                   default:
-                      Log.i("onCallStateChanged", "default");
                       break;
               }
           }
     }
 
     public void stopListenToNativeCallsState() {
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && callStateListener !=null){
-            Log.d(TAG, "[RNCallKeepModule] stopListenToNativeCallsState");
+        Log.d(TAG, "[RNCallKeepModule] stopListenToNativeCallsState");
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && callStateListener !=null){
             telephonyManager.unregisterTelephonyCallback(callStateListener);
-        }else if(Build.VERSION.SDK_INT < Build.VERSION_CODES.S && legacyCallStateListener != null){
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && legacyCallStateListener != null){
             telephonyManager.listen(legacyCallStateListener, PhoneStateListener.LISTEN_NONE);
         }
     }
 
     public void listenToNativeCallsState() {
+        Log.d(TAG, "[RNCallKeepModule] listenToNativeCallsState");
         Context context = this.getAppContext();
         int permissionCheck = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE);
+
         if (permissionCheck == PackageManager.PERMISSION_GRANTED) {
-        Log.d(TAG, "[RNCallKeepModule] listenToNativeCallsState");
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                   callStateListener = new CallStateListener();
                   telephonyManager.registerTelephonyCallback(context.getMainExecutor(),callStateListener);
@@ -331,14 +325,15 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
     public boolean checkIsInManagedCall() {
         Context context = this.getAppContext();
         int permissionCheck = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE);
+
         if (permissionCheck == PackageManager.PERMISSION_GRANTED) {
                 return telecomManager.isInManagedCall();
         }
-         return false;
+        return false;
     }
 
     @ReactMethod
-        public void checkIsInManagedCall(Promise promise) {
+    public void checkIsInManagedCall(Promise promise) {
         boolean isInManagedCall = this.checkIsInManagedCall();
         promise.resolve(isInManagedCall);
     }
@@ -727,20 +722,20 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
 
    @Override
    public void onHostResume() {
-       Log.d(TAG, "onResume()");
+
    }
 
    @Override
    public void onHostPause() {
-       Log.d(TAG, "onPause()");
+
    }
 
    @Override
    public void onHostDestroy() {
-      // when activity destroyed end all calls
-       Log.d(TAG, "onDestroy()");
+       // When activity destroyed end all calls
+       Log.d(TAG, "[RNCallKeepModule] onHostDestroy called");
        if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
-           Log.w(TAG, "[RNCallKeepModule] endAllCalls ignored due to no ConnectionService or no phone account");
+           Log.w(TAG, "[RNCallKeepModule] onHostDestroy ignored due to no ConnectionService or no phone account");
            return;
        }
 
@@ -751,8 +746,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
            connectionToEnd.onDisconnect();
        }
        this.stopListenToNativeCallsState();
-       Log.d(TAG, "[RNCallKeepModule] endAllCalls executed");
-       // this line will kill the android process after ending all calls
+       Log.d(TAG, "[RNCallKeepModule] onHostDestroy executed");
+       // This line will kill the android process after ending all calls
        android.os.Process.killProcess(android.os.Process.myPid());
    }
 

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -218,17 +218,23 @@ public class VoiceConnectionService extends ConnectionService {
     @Override
     public Connection onCreateOutgoingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
         VoiceConnectionService.hasOutgoingCall = true;
-        String uuid = UUID.randomUUID().toString();
 
-        Log.d(TAG, "[VoiceConnectionService] onCreateOutgoingConnection, uuid:" + uuid);
+        Bundle extras = request.getExtras();
+        String callUUID = extras.getString(EXTRA_CALL_UUID);
+
+        if(callUUID == null || callUUID == ""){
+          callUUID = UUID.randomUUID().toString();
+        }
+
+        Log.d(TAG, "[VoiceConnectionService] onCreateOutgoingConnection, uuid:"  + callUUID);
 
         if (!isInitialized && !isReachable) {
-            this.notReachableCallUuid = uuid;
+            this.notReachableCallUuid = callUUID;
             this.currentConnectionRequest = request;
             this.checkReachability();
         }
 
-        return this.makeOutgoingCall(request, uuid, false);
+        return this.makeOutgoingCall(request, callUUID, false);
     }
 
     private Connection makeOutgoingCall(ConnectionRequest request, String uuid, Boolean forceWakeUp) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare module 'react-native-callkeep' {
     checkReachability: 'RNCallKeepCheckReachability';
     didResetProvider: 'RNCallKeepProviderReset';
     didLoadWithEvents: 'RNCallKeepDidLoadWithEvents';
+    onHasActiveCall : 'onHasActiveCall';
   }
 
   export type InitialEvents = Array<{
@@ -54,6 +55,7 @@ declare module 'react-native-callkeep' {
     checkReachability: undefined;
     didResetProvider: undefined;
     didLoadWithEvents: InitialEvents;
+    onHasActiveCall : undefined;
   }
 
   type HandleType = 'generic' | 'number' | 'email';
@@ -74,7 +76,7 @@ declare module 'react-native-callkeep' {
     defaultToSpeaker = 0x8,
     overrideMutedMicrophoneInterruption = 0x80,
   }
-  
+
   export enum AudioSessionMode {
     default = 'AVAudioSessionModeDefault',
     gameChat = 'AVAudioSessionModeGameChat',
@@ -273,5 +275,10 @@ declare module 'react-native-callkeep' {
     static setCurrentCallActive(callUUID: string): void
 
     static backToForeground(): void
+
+    /**
+     * @descriptions Android Only, Check if there is active native call
+     */
+    static checkIsInManagedCall(): Promise<boolean>
   }
 }

--- a/index.js
+++ b/index.js
@@ -161,6 +161,8 @@ class RNCallKeep {
     );
   };
 
+  checkIsInManagedCall = async () => isIOS? false: RNCallKeepModule.checkIsInManagedCall();
+
   answerIncomingCall = (uuid) => {
     RNCallKeepModule.answerIncomingCall(uuid);
   };


### PR DESCRIPTION
This PR deliver some fixes & new code 

1- `checkIsInManagedCall` was added to check if there is a native active call in android, in my case this was useful to check if there is a native active call, prevent app from making a call

2- `onHasActiveCall` was added to tell the JS side about native call status, in my case this covered the case where you are in an app call then you accept a native call, this will trigger this event which i end the call by it. so no two calls be on the same time. before, the two calls were running at the same time

3- change in VoiceConnectionService.java is to fix #625

4- `onHostDestroy` has been added to stop all calls and processes when app is killed