### PR TITLE
Add missing minimum API level annotation

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -38,6 +38,7 @@ import android.os.Bundle;
 import android.view.WindowManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -262,6 +263,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
          }
     }
 
+    @RequiresApi(Build.VERSION_CODES.S)
     private class CallStateListener extends TelephonyCallback implements TelephonyCallback.CallStateListener {
 
           @Override


### PR DESCRIPTION
The use of TelephonyCallback was introduced in react-native-webrtc#724 which is only supported on Android SDK v31+.

I have added an `@RequiresApi` annotation to maintain compatibility with lower versions.