### PR TITLE
Fix getAudioRoutes definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ RNCallKeep.toggleAudioRouteSpeaker(uuid, true);
 Get the list of available audio routes. i.e. bluetooth, wired/ear-piece, speaker and phone.
 
 ```js
-await RNCallKeep.getAudioRoutes(): AudioRoute;
+await RNCallKeep.getAudioRoutes(): AudioRoute[];
 ```
 
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -222,7 +222,7 @@ declare module 'react-native-callkeep' {
       outgoing: boolean
     }[] | void>
 
-    static getAudioRoutes(): Promise<void>
+    static getAudioRoutes(): Promise<AudioRoute[]>
 
     static setAudioRoute: (uuid: string, inputName: string) => Promise<void>
 


### PR DESCRIPTION
Fixes #748.

As described in that issue, `getAudioRoutes()` currently returns a `Promise<void>`. It should be returning `Promise<AudioRoute[]>` [as described in the documentation](https://github.com/react-native-webrtc/react-native-callkeep#getaudioroutes) and [the Java module](https://github.com/react-native-webrtc/react-native-callkeep/blob/cc308ce2ed33bcc12ef1ef95468f4a81de7d6d4e/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java#L856).