### PR TITLE
Stop listening phone event ended

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -718,6 +718,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
             return;
         }
         conn.reportDisconnect(reason);
+
+        this.stopListenToNativeCallsState();
     }
 
    @Override

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -382,18 +382,22 @@ public class VoiceConnectionService extends ConnectionService {
         // Avoid to call wake up the app again in wakeUpAfterReachabilityTimeout.
         this.currentConnectionRequest = null;
 
-        Intent headlessIntent = new Intent(
-            this.getApplicationContext(),
-            RNCallKeepBackgroundMessagingService.class
-        );
-        headlessIntent.putExtra("callUUID", uuid);
-        headlessIntent.putExtra("name", displayName);
-        headlessIntent.putExtra("handle", number);
+        try {
+            Intent headlessIntent = new Intent(
+                this.getApplicationContext(),
+                RNCallKeepBackgroundMessagingService.class
+            );
+            headlessIntent.putExtra("callUUID", uuid);
+            headlessIntent.putExtra("name", displayName);
+            headlessIntent.putExtra("handle", number);
 
-        ComponentName name = this.getApplicationContext().startService(headlessIntent);
-        if (name != null) {
-          Log.d(TAG, "[VoiceConnectionService] wakeUpApplication, acquiring lock for application:" + name);
-          HeadlessJsTaskService.acquireWakeLockNow(this.getApplicationContext());
+            ComponentName name = this.getApplicationContext().startService(headlessIntent);
+            if (name != null) {
+              Log.d(TAG, "[VoiceConnectionService] wakeUpApplication, acquiring lock for application:" + name);
+              HeadlessJsTaskService.acquireWakeLockNow(this.getApplicationContext());
+            }
+        } catch (Exception e) {
+          Log.w(TAG, "[VoiceConnectionService] wakeUpApplication, error" + e.toString());
         }
     }
 


### PR DESCRIPTION
Avoid error when calling `reportEndCallWithUUID` and not `endCall` :
```
java.lang.IllegalStateException: Pid 10702 has exceeded the number of permissible registered listeners. Ignoring request to add
```