### PR TITLE
add Android RN 0.73 Support - Update build.gradle w/ Namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,11 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace = "io.wazo.callkeep"
+    }
 }
 
 repositories {


### PR DESCRIPTION
follow https://stackoverflow.com/questions/76108428/how-do-i-fix-namespace-not-specified-error-in-android-studio

and https://github.com/getsentry/sentry-react-native/blob/main/android/build.gradle#L17C5-L20C6

which fixed Android Gradle Plugin error >= 8.x.x