### PR TITLE
Issue/st 5786 bluetooth

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.wazo.callkeep">
 
-    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <!-- <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE"
                      android:maxSdkVersion="29" />
-    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" /> -->
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
 </manifest>

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -889,7 +889,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
 
     private String getAudioRouteType(int type){
         switch (type){
-            case(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP):
             case(AudioDeviceInfo.TYPE_BLUETOOTH_SCO):
                 return "Bluetooth";
             case(AudioDeviceInfo.TYPE_WIRED_HEADPHONES):

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -896,6 +896,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
             case(AudioDeviceInfo.TYPE_WIRED_HEADSET):
                 return "Headset";
             case(AudioDeviceInfo.TYPE_BUILTIN_MIC):
+            case(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE):
                 return "Phone";
             case(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER):
                 return "Speaker";
@@ -905,7 +906,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
     }
 
     private String getSelectedAudioRoute(AudioManager audioManager){
-        if(audioManager.isBluetoothScoOn()){
+        if(audioManager.isBluetoothScoOn() || audioManager.isBluetoothA2dpOn()){
             return "Bluetooth";
         }
         if(audioManager.isSpeakerphoneOn()){

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -458,19 +458,9 @@ public class VoiceConnectionService extends ConnectionService {
         VoiceConnection connection = new VoiceConnection(this, extrasMap);
         connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE | Connection.CAPABILITY_SUPPORT_HOLD);
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            Context context = getApplicationContext();
-            TelecomManager telecomManager = (TelecomManager) context.getSystemService(context.TELECOM_SERVICE);
-            PhoneAccount phoneAccount = telecomManager.getPhoneAccount(request.getAccountHandle());
-
-            //If the phone account is self managed, then this connection must also be self managed.
-            if((phoneAccount.getCapabilities() & PhoneAccount.CAPABILITY_SELF_MANAGED) == PhoneAccount.CAPABILITY_SELF_MANAGED) {
-                Log.d(TAG, "[VoiceConnectionService] PhoneAccount is SELF_MANAGED, so connection will be too");
-                connection.setConnectionProperties(Connection.PROPERTY_SELF_MANAGED);
-            }
-            else {
-                Log.d(TAG, "[VoiceConnectionService] PhoneAccount is not SELF_MANAGED, so connection won't be either");
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Patch: we only use a self-managed connection service, so skip the check to getPhoneAccount() so we don't require the READ_PHONE_NUMBERS/READ_PHONE_STATE permissions
+            connection.setConnectionProperties(Connection.PROPERTY_SELF_MANAGED);
         }
 
         connection.setInitializing();

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -37,14 +37,14 @@ static NSString *const RNCallKeepProviderReset = @"RNCallKeepProviderReset";
 static NSString *const RNCallKeepCheckReachability = @"RNCallKeepCheckReachability";
 static NSString *const RNCallKeepDidChangeAudioRoute = @"RNCallKeepDidChangeAudioRoute";
 static NSString *const RNCallKeepDidLoadWithEvents = @"RNCallKeepDidLoadWithEvents";
+bool _isSpeakerOn;
 
 @implementation RNCallKeep
 {
     NSOperatingSystemVersion _version;
     BOOL _isStartCallActionEventListenerAdded;
     bool _hasListeners;
-    bool _isReachable;
-    bool _isSpeakerOn;
+    bool _isReachable;    
     NSMutableArray *_delayedEvents;
 }
 
@@ -163,9 +163,9 @@ RCT_EXPORT_MODULE()
         NSDictionary *body = @{
             @"output": output,
             @"reason": @(reason),
-    };
-
-    [self sendEventWithName:RNCallKeepDidChangeAudioRoute body:body];
+        };
+        [self sendEventWithName:RNCallKeepDidChangeAudioRoute body:body];
+    }
 }
 
 - (void)sendEventWithNameWrapper:(NSString *)name body:(id)body {


### PR DESCRIPTION
This PR makes it so that `getAudioDevices` only cares about bluetooth devices that work with telephony.

I believe the [A2DP](https://developer.android.com/reference/android/media/AudioDeviceInfo#TYPE_BLUETOOTH_A2DP) bluetooth type is for the audio flag? It basically is always returned even with the "Calls" bluetooth setting OFF. However the [SCO](https://developer.android.com/reference/android/media/AudioDeviceInfo#TYPE_BLUETOOTH_SCO) bluetooth type is only returned when the "Calls" bluetooth setting is ON. 

So the fix should only be including the `SCO` type as "Bluetooth".

