### PR TITLE
Use reactContent instead of getReactApplicationContext to avoid invalid catalyst instance error

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -588,7 +588,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
                allPermissionaw.pushString(allPermission);
             }
 
-            getReactApplicationContext()
+            this.reactContext
                 .getNativeModule(PermissionsModule.class)
                 .requestMultiplePermissions(allPermissionaw, new Promise() {
                     @Override


### PR DESCRIPTION
Fix `Trying to call native module before CatalystInstance has been set` error thrown when not in self managed mode.