### PR TITLE
Update Android installation steps for Android 14 (target SDK 34) onwards

### DIFF
--- a/docs/android-installation.md
+++ b/docs/android-installation.md
@@ -66,6 +66,9 @@ public class MainActivity extends ReactActivity {
 <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 <uses-permission android:name="android.permission.CALL_PHONE" />
 <uses-permission android:name="android.permission.RECORD_AUDIO" />
+// Use this to target android >= 14
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
 
 <application>
     // ...


### PR DESCRIPTION
Since Android 14 it is required to add foreground service type to the Android Manifest. More info here: https://developer.android.com/about/versions/14/changes/fgs-types-required. 

This PR is adding required permissions to the installation steps.