### PR TITLE
Fix setAudioRoutes method in ios

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -515,11 +515,17 @@ RCT_EXPORT_METHOD(setAudioRoute: (NSString *)uuid
     @try {
         NSError* err = nil;
         AVAudioSession* myAudioSession = [AVAudioSession sharedInstance];
+        [myAudioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:&err];
+
         if ([inputName isEqualToString:@"Speaker"]) {
             BOOL isOverrided = [myAudioSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&err];
+
+            [myAudioSession setActive:YES error:&err];
+
             if(!isOverrided){
                 [NSException raise:@"overrideOutputAudioPort failed" format:@"error: %@", err];
             }
+
             resolve(@"Speaker");
             return;
         }
@@ -528,9 +534,13 @@ RCT_EXPORT_METHOD(setAudioRoute: (NSString *)uuid
         for (AVAudioSessionPortDescription *port in ports) {
             if ([port.portName isEqualToString:inputName]) {
                 BOOL isSetted = [myAudioSession setPreferredInput:(AVAudioSessionPortDescription *)port error:&err];
+
+                [myAudioSession setActive:YES error:&err];
+
                 if(!isSetted){
                     [NSException raise:@"setPreferredInput failed" format:@"error: %@", err];
                 }
+
                 resolve(inputName);
                 return;
             }


### PR DESCRIPTION
Hello every one!

I saw a problem  when change audio route from app in this time in call kit audio route icon is not changed.

I have changed logic in setAudioRoute function.
- set category - AVAudioSessionCategoryPlayAndRecord for audio session
- mark this session as active

I'm not shure that this logic is true way.  If some one know better way, make code review pls. I will fix this PR
