### PR TITLE
remove duplicate definitions of startcall and displayincomingcall as …

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -428,10 +428,10 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
         this.hasListeners = false;
     }
 
-    @ReactMethod
-    public void displayIncomingCall(String uuid, String number, String callerName) {
-        this.displayIncomingCall(uuid, number, callerName, false, null);
-    }
+    // @ReactMethod
+    // public void displayIncomingCall(String uuid, String number, String callerName) {
+    //     this.displayIncomingCall(uuid, number, callerName, false, null);
+    // }
 
     @ReactMethod
     public void displayIncomingCall(String uuid, String number, String callerName, boolean hasVideo) {
@@ -477,10 +477,10 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
         conn.onAnswer();
     }
 
-    @ReactMethod
-    public void startCall(String uuid, String number, String callerName) {
-        this.startCall(uuid, number, callerName, false, null);
-    }
+    // @ReactMethod
+    // public void startCall(String uuid, String number, String callerName) {
+    //     this.startCall(uuid, number, callerName, false, null);
+    // }
 
     @ReactMethod
     public void startCall(String uuid, String number, String callerName, boolean hasVideo) {

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -428,11 +428,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
         this.hasListeners = false;
     }
 
-    // @ReactMethod
-    // public void displayIncomingCall(String uuid, String number, String callerName) {
-    //     this.displayIncomingCall(uuid, number, callerName, false, null);
-    // }
-
     @ReactMethod
     public void displayIncomingCall(String uuid, String number, String callerName, boolean hasVideo) {
         this.displayIncomingCall(uuid, number, callerName, hasVideo, null);
@@ -476,11 +471,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
 
         conn.onAnswer();
     }
-
-    // @ReactMethod
-    // public void startCall(String uuid, String number, String callerName) {
-    //     this.startCall(uuid, number, callerName, false, null);
-    // }
 
     @ReactMethod
     public void startCall(String uuid, String number, String callerName, boolean hasVideo) {


### PR DESCRIPTION
…react native is thorwing error with the latest version. When upgrading to the latest version of react native (0.76.1), I got this error that RNCallKeep is exporting two methods with same name (got this error for two methods, startCall and displayIncomingCall).