### PR TITLE
Keep foregroundService active if there is other connections

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -156,10 +156,15 @@ public class VoiceConnectionService extends ConnectionService {
         Log.d(TAG, "[VoiceConnectionService] deinitConnection:" + connectionId);
         VoiceConnectionService.hasOutgoingCall = false;
 
-        currentConnectionService.stopForegroundService();
-
         if (currentConnections.containsKey(connectionId)) {
             currentConnections.remove(connectionId);
+        }
+        
+        if (currentConnections.isEmpty()) {
+            Log.d(TAG, "[VoiceConnectionService] deinitConnection. No other connections left -> RUN stopForegroundService!");
+            currentConnectionService.stopForegroundService();
+        } else {
+            Log.d(TAG, "[VoiceConnectionService] deinitConnection. There still exist other connections -> NO stopForegroundService!");
         }
     }
 


### PR DESCRIPTION
Hi!
Imagine that you received a call while your app is in the background, accepted it and now have an active conversation.
Then you receive a second incoming call. In that case you may decline second call at once, or you may put on hold the first call and accept the second one, then after a while you finish your conversation and press hang up button, or remote party presses it and you should invoke endCall method to hide second call screen. Anyway, after finishing or declining you going to get back to first call, remove from hold (if needed) and resume conversation. But in all that cases mentioned above you will find that remote party can't hear you anymore.
It happens because any kind of finish of second call fires endCall event which leads unconditionally to currentConnectionService.stopForegroundService() method, therefore your app loses access to microphone in background.
My solution is making a check wether other connections still exist and invoke stopForegroundService only if not.