### PR TITLE
fix IllegalStateException

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -304,7 +304,9 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
             telephonyManager.unregisterTelephonyCallback(callStateListener);
         } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && legacyCallStateListener != null){
             telephonyManager.listen(legacyCallStateListener, PhoneStateListener.LISTEN_NONE);
-            Looper.myLooper().quit();
+            if (Looper.myLooper() != null) {
+                Looper.myLooper().quit();
+            }
         }
     }
 


### PR DESCRIPTION
NOTE: This change is not properly tested. 

PR explanation:
I was getting `IllegalStateException` from the this line of code `Looper.myLooper().quit();` which mostly occured because `Looper.myLooper` was `null`.

Added a condition to check if `Looper.myLooper` is not `null`, then only call `quit` method.