### PR TITLE
Send NString to a reject function instead of NSException. React-Native 0.79

### DIFF
--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -538,7 +538,7 @@ RCT_EXPORT_METHOD(setAudioRoute: (NSString *)uuid
     }
     @catch ( NSException *e ){
         NSLog(@"[RNCallKeep][setAudioRoute] exception: %@",e);
-        reject(@"Failure to set audio route", e, nil);
+        reject(@"Failure to set audio route", e.description, nil);
     }
 }
 
@@ -555,7 +555,7 @@ RCT_EXPORT_METHOD(getAudioRoutes: (RCTPromiseResolveBlock)resolve
     }
     @catch ( NSException *e ) {
         NSLog(@"[RNCallKeep][getAudioRoutes] exception: %@",e);
-        reject(@"Failure to get audio routes", e, nil);
+        reject(@"Failure to get audio routes", e.description, nil);
     }
 }
 


### PR DESCRIPTION
In react-native 0.79 reject interface are changed. We should send NSString instead of NSException